### PR TITLE
[manifest] #5 add a script to compute the version of package

### DIFF
--- a/manifest-build-tools/HWIMO-BUILD
+++ b/manifest-build-tools/HWIMO-BUILD
@@ -31,7 +31,7 @@ BASEDIR=$(dirname "$0")
 
 if [ ! -d $BASEDIR/env/hwimobuild -o $BASEDIR/requirements.txt -nt $BASEDIR/env/hwimobuild ]
 then
-  echo -n "Creating virtual environment... "
+  echo -n "Creating virtual environment... " > $BASEDIR/environment.log
   set +e
   (cd $BASEDIR; ./mkenv.sh hwimobuild) > $BASEDIR/environment.log 2>&1
   if [ $? != 0 ]
@@ -45,7 +45,7 @@ then
     fi
     exit 1
   fi
-  echo 'done!'
+  echo 'done!' > $BASEDIR/environment.log
 fi
 
 source $BASEDIR/env/hwimobuild/bin/activate

--- a/manifest-build-tools/application/version_generator.py
+++ b/manifest-build-tools/application/version_generator.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+# Copyright 2015-2016, EMC, Inc.
+
+"""
+The script compute the version of a package, just like:
+1.1-1-devel-20160809150908-7396d91
+
+usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/version_generator.py 
+--repo-dir /home/onrack/rackhd/release/rackhd-repos/PengTian0/b/b/on-http
+
+"""
+import os
+import sys
+import argparse
+import datetime
+import subprocess
+from RepositoryOperator import RepoOperator
+from common import *
+
+class VersionGenerator(object):
+    def __init__(self, repo_dir):
+        """
+        :return:
+ 
+        """
+        self._repo_dir = repo_dir
+        self.repo_operator = RepoOperator()
+ 
+    def generate_small_version(self):
+        """
+        generate the small version which consists of commit date and commit hash
+        return: small version 
+        """
+
+        ts_str = self.repo_operator.get_lastest_commit_date(self._repo_dir)
+        date = datetime.datetime.utcfromtimestamp(int(ts_str)).strftime('%Y%m%d%H%M%SZ')
+        commit_id = self.repo_operator.get_lastest_commit_id(self._repo_dir)
+        version = "{date}-{commit}".format(date=date, commit=commit_id[0:7])
+        return version              
+
+    def generate_big_version(self):
+        """
+        generate the big version according to changelog
+        return: big version
+        """
+        #If the repository is on-http, sync the debianstatic/on-http/ to debian before compute version
+        repo_url = self.repo_operator.get_repo_url(self._repo_dir)
+        repo_name = strip_suffix(os.path.basename(repo_url), ".git")
+        if repo_name == "on-http":
+            cmd_args = ["rsync", "-ar", "debianstatic/on-http/", "debian"]
+            proc = subprocess.Popen(cmd_args,
+                                    cwd=self._repo_dir,
+                                    stderr=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    shell=False)
+
+            (out, err) = proc.communicate()
+            if proc.returncode != 0:
+                raise RuntimeError("Failed to sync on-http/debianstatic/on-http to on-http/debian due to {0}".format(err))
+                
+        cmd_args = ["dpkg-parsechangelog", "--show-field", "Version"]
+        proc = subprocess.Popen(cmd_args,
+                                cwd=self._repo_dir,
+                                stderr=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                shell=False)
+
+        (out, err) = proc.communicate()
+        if proc.returncode == 0:
+            return out.strip()
+        else:
+            print "Failed to parse version in debian/changelog due to {0}".format(err)
+            return None
+
+        
+    def generate_candidate_version(self):
+        """
+        generate the candidate version according to branch
+        return: devel ,if the branch is master
+                rc, if the branch is not master
+        """
+        current_branch = self.repo_operator.get_current_branch(self._repo_dir)
+        candidate_version = ""
+        if "master" in current_branch:
+            candidate_version = "devel"
+        else:
+            candidate_version = "rc"
+        return candidate_version
+        
+
+    def generate_package_version(self, is_official_release):
+        """
+        generate the version of package, just like:
+        1.1-1-devel-20160809150908-7396d91 or 1.1-1
+        :return: package version
+        """
+        big_version = self.generate_big_version()
+        if big_version is None:
+            print "Failed to generate big version, maybe the {0} doesn't contain debian directory".format(self._repo_dir)
+            return None
+
+        if is_official_release:
+            version = big_version
+        else:
+            candidate_version = self.generate_candidate_version()
+            small_version = self.generate_small_version()
+
+            if candidate_version is None or small_version is None:
+                raise RuntimeError("Failed to generate version for {0}, due to the candidate version or small version is None".format(self._repo_dir))
+
+            version = "{0}~{1}-{2}".format(big_version, candidate_version, small_version)
+        
+        return version
+
+def parse_command_line(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-dir",
+                        required=True,
+                        help="the directory of repository",
+                        action="store")
+    parser.add_argument("--is-official-release",
+                        default=False,
+                        help="This release if official",
+                        action="store_true")
+    parser.add_argument('--parameter-file',
+                        help="The jenkins parameter file that will used for succeeding Jenkins job",
+                        action='store',
+                        default="downstream_parameters")
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+def write_downstream_parameters(filename, params):
+    """
+    Add/append downstream parameter (java variable value pair) to the given
+    parameter file. If the file does not exist, then create the file.
+
+    :param filename: The parameter file that will be used for making environment
+     variable for downstream job.
+    :param params: the parameters dictionary
+
+    :return:
+            None on success
+            Raise any error if there is any
+    """
+    if filename is None:
+        return
+
+    with open(filename, 'w') as fp:
+        try:
+            for key in params:
+                entry = "{key}={value}\n".format(key=key, value=params[key])
+                fp.write(entry)
+        except IOError:
+            print "Unable to write parameter(s) for next step(s), exit"
+            exit(2)
+
+def main():
+    # parse arguments
+    args = parse_command_line(sys.argv[1:])
+
+    generator = VersionGenerator(args.repo_dir)
+    try:
+        version = generator.generate_package_version(args.is_official_release)
+
+        # write parameters to parameter file
+        downstream_parameters = {}
+        downstream_parameters['PKG_VERSION'] = version
+        write_downstream_parameters(args.parameter_file, downstream_parameters)
+    except Exception, e:
+        print "Failed to generate version for {0} due to {1}\n Exiting now".format(args.repo_dir, e)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/manifest-build-tools/application/version_generator.py
+++ b/manifest-build-tools/application/version_generator.py
@@ -74,7 +74,15 @@ class VersionGenerator(object):
             (out, err) = proc.communicate()
             if proc.returncode != 0:
                 raise RuntimeError("Failed to sync on-http/debianstatic/on-http to on-http/debian due to {0}".format(err))
-                
+ 
+        debian_exist = False
+        if os.path.isdir(self._repo_dir):
+            for filename in os.listdir(self._repo_dir):
+                if filename == "debian":
+                    debian_exist = True
+        if debian_exist == False:
+            return None
+               
         cmd_args = ["dpkg-parsechangelog", "--show-field", "Version"]
         proc = subprocess.Popen(cmd_args,
                                 cwd=self._repo_dir,
@@ -86,9 +94,7 @@ class VersionGenerator(object):
         if proc.returncode == 0:
             return out.strip()
         else:
-            print "Failed to parse version in debian/changelog due to {0}".format(err)
-            return None
-
+            raise RuntimeError("Failed to parse version in debian/changelog due to {0}".format(err))
         
     def generate_version_stage(self):
         """

--- a/manifest-build-tools/application/version_generator.py
+++ b/manifest-build-tools/application/version_generator.py
@@ -124,7 +124,7 @@ class VersionGenerator(object):
         """
         big_version = self.generate_big_version()
         if big_version is None:
-            print "Failed to generate big version, maybe the {0} doesn't contain debian directory".format(self._repo_dir)
+            logging.warning("Failed to generate big version, maybe the {0} doesn't contain debian directory".format(self._repo_dir))
             return None
 
         if is_official_release:
@@ -159,39 +159,16 @@ def parse_command_line(args):
                         default=False,
                         help="This release if official",
                         action="store_true")
+
+    """
     parser.add_argument('--parameter-file',
                         help="The jenkins parameter file that will be used for succeeding Jenkins job",
                         action='store',
                         default="release_version")
+    """
 
     parsed_args = parser.parse_args(args)
     return parsed_args
-
-
-def write_downstream_parameters(filename, params):
-    """
-    Add/append downstream parameter (java variable value pair) to the given
-    parameter file. If the file does not exist, then create the file.
-
-    :param filename: The parameter file that will be used for making environment
-     variable for downstream job.
-    :param params: the parameters dictionary
-
-    :return:
-            None on success
-            Raise any error if there is any
-    """
-    if filename is None:
-        return
-
-    with open(filename, 'w') as fp:
-        try:
-            for key in params:
-                entry = "{key}={value}\n".format(key=key, value=params[key])
-                fp.write(entry)
-        except IOError:
-            print "Unable to write parameter(s) for next step(s), exit"
-            exit(2)
 
 def main():
     # parse arguments
@@ -200,12 +177,9 @@ def main():
     generator = VersionGenerator(args.repo_dir, args.manifest_repo_dir)
     try:
         version = generator.generate_package_version(args.is_official_release)
-        # write parameters to parameter file
-        downstream_parameters = {}
-        downstream_parameters['PKG_VERSION'] = version
-        write_downstream_parameters(args.parameter_file, downstream_parameters)
+        print version
     except Exception, e:
-        print "Failed to generate version for {0} due to {1}\n Exiting now".format(args.repo_dir, e)
+        logging.error("Failed to generate version for {0} due to {1}\n Exiting now".format(args.repo_dir, e))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/manifest-build-tools/application/version_generator.py
+++ b/manifest-build-tools/application/version_generator.py
@@ -63,7 +63,7 @@ class VersionGenerator(object):
             return version
         else:
             commit_timestamp_str = self.repo_operator.get_lastest_commit_date(self._repo_dir)
-            date = datetime.utcfromtimestamp(int(commit_timestamp_str)).strftime('%Y%m%d%H%M%SZ')
+            date = datetime.utcfromtimestamp(int(commit_timestamp_str)).strftime('%Y%m%dUTC')
             commit_id = self.repo_operator.get_lastest_commit_id(self._repo_dir)
             version = "{date}-{commit}".format(date=date, commit=commit_id[0:7])
             return version
@@ -156,13 +156,13 @@ def parse_command_line(args):
                         help="the directory of repository",
                         action="store")
 
-    parser.add_argument("--is-official-release",
-                        type=bool,
-                        default=False,
-                        help="whether this release is official",
+    parser.add_argument('--is-official-release',
+                        default="false",
+                        help="Whether this release is official",
                         action="store")
 
     parsed_args = parser.parse_args(args)
+    parsed_args.is_official_release = common.str2bool(parsed_args.is_official_release)
     return parsed_args
 
 def main():

--- a/manifest-build-tools/application/version_generator.py
+++ b/manifest-build-tools/application/version_generator.py
@@ -40,7 +40,8 @@ class VersionGenerator(object):
  
     def generate_small_version(self):
         """
-        generate the small version which consists of commit date and commit hash
+        Generate the small version which consists of commit date and commit hash of manifest repository
+        According to small version, users can track the commit of all repositories in manifest file
         return: small version 
         """
 
@@ -52,7 +53,8 @@ class VersionGenerator(object):
 
     def generate_big_version(self):
         """
-        generate the big version according to changelog
+        Generate the big version according to changelog
+        The big version is the latest version of debian/changelog
         return: big version
         """
         #If the repository is on-http, sync the debianstatic/on-http/ to debian before compute version
@@ -85,19 +87,19 @@ class VersionGenerator(object):
             return None
 
         
-    def generate_candidate_version(self):
+    def generate_version_stage(self):
         """
-        generate the candidate version according to branch
+        Generate the version stage according to the stage of deveplopment
         return: devel ,if the branch is master
                 rc, if the branch is not master
         """
         current_branch = self.repo_operator.get_current_branch(self._repo_dir)
-        candidate_version = ""
+        version_stage = ""
         if "master" in current_branch:
-            candidate_version = "devel"
+            version_stage = "devel"
         else:
-            candidate_version = "rc"
-        return candidate_version
+            version_stage = "rc"
+        return version_stage
         
     def generate_package_version(self, is_official_release):
         """
@@ -113,13 +115,13 @@ class VersionGenerator(object):
         if is_official_release:
             version = big_version
         else:
-            candidate_version = self.generate_candidate_version()
+            version_stage = self.generate_version_stage()
             small_version = self.generate_small_version()
 
-            if candidate_version is None or small_version is None:
+            if version_stage is None or small_version is None:
                 raise RuntimeError("Failed to generate version for {0}, due to the candidate version or small version is None".format(self._repo_dir))
 
-            version = "{0}~{1}-{2}".format(big_version, candidate_version, small_version)
+            version = "{0}~{1}-{2}".format(big_version, version_stage, small_version)
         
         return version
 
@@ -143,7 +145,7 @@ def parse_command_line(args):
                         help="This release if official",
                         action="store_true")
     parser.add_argument('--parameter-file',
-                        help="The jenkins parameter file that will used for succeeding Jenkins job",
+                        help="The jenkins parameter file that will be used for succeeding Jenkins job",
                         action='store',
                         default="release_version")
 

--- a/manifest-build-tools/application/version_generator.py
+++ b/manifest-build-tools/application/version_generator.py
@@ -3,34 +3,36 @@
 
 """
 The script compute the version of a package, just like:
-1.1-1-devel-20160809150908-7396d91
+1.1-1-20161129UTC
 
 usage:
-./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/version_generator.py 
---repo-dir /home/onrack/rackhd/release/rackhd-repos/PengTian0/b/b/on-http
---manifest-repo-dir /home/onrack/rackhd/release/rackhd-repos/PengTian0/b/build-manifests
---is-official-release
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/version_generator.py \
+--repo-dir /home/onrack/rackhd/release/rackhd-repos/PengTian0/b/b/on-http \
+--is-official-release true
 
 Because this script need to import scripts under lib.
 The script HWIMO-BUILD helps to add the scripts under lib to python path.
 
 The required parameters: 
-repo-dir
-manifest-repo-dir
+repo-dir: the directory of the repository
 
 The optional parameters:
-is-official-release (default value is false)
+is-official-release: whether the release is official (default value is false)
 """
 import os
 import sys
 import argparse
-import datetime
-import subprocess
-from RepositoryOperator import RepoOperator
-from common import *
+from datetime import datetime,timedelta
+
+try:
+    from RepositoryOperator import RepoOperator
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
 
 class VersionGenerator(object):
-    def __init__(self, repo_dir, manifest_repo_dir):
+    def __init__(self, repo_dir):
         """
         This module compute the version of a repository
         The version for candidate release: {big-version}~{version-stage}-{small-version}
@@ -40,21 +42,31 @@ class VersionGenerator(object):
         :return:None
         """
         self._repo_dir = repo_dir
-        self._manifest_repo_dir = manifest_repo_dir
         self.repo_operator = RepoOperator()
- 
+        self._repo_name = self.get_repo_name()
+
+    def get_repo_name(self):
+        repo_url = self.repo_operator.get_repo_url(self._repo_dir)
+        repo_name = common.strip_suffix(os.path.basename(repo_url), ".git")
+        return repo_name
+
     def generate_small_version(self):
         """
         Generate the small version which consists of commit date and commit hash of manifest repository
         According to small version, users can track the commit of all repositories in manifest file
         return: small version 
         """
-
-        ts_str = self.repo_operator.get_lastest_commit_date(self._manifest_repo_dir)
-        date = datetime.datetime.utcfromtimestamp(int(ts_str)).strftime('%Y%m%d%H%M%SZ')
-        commit_id = self.repo_operator.get_lastest_commit_id(self._manifest_repo_dir)
-        version = "{date}-{commit}".format(date=date, commit=commit_id[0:7])
-        return version
+        if self._repo_name == "RackHD":
+            utc_now = datetime.utcnow()
+            utc_yesterday = utc_now + timedelta(days=-1)
+            version = utc_yesterday.strftime('%Y%m%dUTC')
+            return version
+        else:
+            commit_timestamp_str = self.repo_operator.get_lastest_commit_date(self._repo_dir)
+            date = datetime.utcfromtimestamp(int(commit_timestamp_str)).strftime('%Y%m%d%H%M%SZ')
+            commit_id = self.repo_operator.get_lastest_commit_id(self._repo_dir)
+            version = "{date}-{commit}".format(date=date, commit=commit_id[0:7])
+            return version
 
     def debian_exist(self):
         """
@@ -74,8 +86,6 @@ class VersionGenerator(object):
         The big version is the latest version of debian/changelog
         return: big version
         """
-        repo_url = self.repo_operator.get_repo_url(self._repo_dir)
-        repo_name = strip_suffix(os.path.basename(repo_url), ".git")
         # If the repository has the debianstatic/repository name/,
         # create a soft link to debian before compute version
         debian_exist = self.debian_exist()
@@ -85,28 +95,20 @@ class VersionGenerator(object):
                 if filename == "debianstatic":
                     debianstatic_dir = os.path.join(self._repo_dir, "debianstatic")
                     for debianstatic_filename in os.listdir(debianstatic_dir):
-                        if debianstatic_filename == repo_name:
-                            debianstatic_repo_dir = "debianstatic/{0}".format(repo_name)
-                            link_dir(debianstatic_repo_dir, "debian", self._repo_dir)
+                        if debianstatic_filename == self._repo_name:
+                            debianstatic_repo_dir = "debianstatic/{0}".format(self._repo_name)
+                            common.link_dir(debianstatic_repo_dir, "debian", self._repo_dir)
                             linked = True
         if not debian_exist and not linked:
             return None
         cmd_args = ["dpkg-parsechangelog", "--show-field", "Version"]
-        proc = subprocess.Popen(cmd_args,
-                                cwd=self._repo_dir,
-                                stderr=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                shell=False)
-        (out, err) = proc.communicate()
+        version = common.run_command(cmd_args, directory=self._repo_dir)
 
         if linked:
             os.remove(os.path.join(self._repo_dir, "debian"))
 
-        if proc.returncode == 0:
-            return out.strip()
-        else:
-            raise RuntimeError("Failed to parse version in debian/changelog due to {0}".format(err))
-        
+        return version
+
     def generate_version_stage(self):
         """
         Generate the version stage according to the stage of deveplopment
@@ -129,19 +131,17 @@ class VersionGenerator(object):
         """
         big_version = self.generate_big_version()
         if big_version is None:
-            logging.warning("Failed to generate big version, maybe the {0} doesn't contain debian directory".format(self._repo_dir))
+            common.logging.warning("Failed to generate big version, maybe the {0} doesn't contain debian directory".format(self._repo_dir))
             return None
 
         if is_official_release:
             version = big_version
         else:
-            version_stage = self.generate_version_stage()
             small_version = self.generate_small_version()
+            if small_version is None:
+                raise RuntimeError("Failed to generate version for {0}, due to the small version is None".format(self._repo_dir))
 
-            if version_stage is None or small_version is None:
-                raise RuntimeError("Failed to generate version for {0}, due to the candidate version or small version is None".format(self._repo_dir))
-
-            version = "{0}~{1}-{2}".format(big_version, version_stage, small_version)
+            version = "{0}-{1}".format(big_version, small_version)
         
         return version
 
@@ -155,15 +155,12 @@ def parse_command_line(args):
                         required=True,
                         help="the directory of repository",
                         action="store")
-    parser.add_argument("--manifest-repo-dir",
-                        required=True,
-                        help="the directory of manifest repository",
-                        action="store")
 
     parser.add_argument("--is-official-release",
+                        type=bool,
                         default=False,
-                        help="This release if official",
-                        action="store_true")
+                        help="whether this release is official",
+                        action="store")
 
     parsed_args = parser.parse_args(args)
     return parsed_args
@@ -171,12 +168,12 @@ def parse_command_line(args):
 def main():
     # parse arguments
     args = parse_command_line(sys.argv[1:])
-    generator = VersionGenerator(args.repo_dir, args.manifest_repo_dir)
+    generator = VersionGenerator(args.repo_dir)
     try:
         version = generator.generate_package_version(args.is_official_release)
         print version
     except Exception, e:
-        logging.error("Failed to generate version for {0} due to {1}\n Exiting now".format(args.repo_dir, e))
+        common.logging.error("Failed to generate version for {0} due to {1}\n Exiting now".format(args.repo_dir, e))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/manifest-build-tools/lib/common.py
+++ b/manifest-build-tools/lib/common.py
@@ -1,5 +1,7 @@
 # Copyright 2016, EMC, Inc.
 
+import subprocess
+
 def strip_suffix(text, suffix):
     """
     Cut a set of the last characters from a provided string
@@ -18,3 +20,16 @@ def strip_prefix(text, prefix):
         return text[len(prefix):]
     else:
         return text
+
+def link_dir(src, dest, dir):
+    cmd_args = ["ln", "-s", src, dest]
+    proc = subprocess.Popen(cmd_args,
+                            cwd=dir,
+                            stderr=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
+                            shell=False)
+    (out, err) = proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError("Failed to sync {0} to {1} due to {2}".format(src, dest, err))
+
+

--- a/manifest-build-tools/lib/common.py
+++ b/manifest-build-tools/lib/common.py
@@ -1,6 +1,10 @@
 # Copyright 2016, EMC, Inc.
 
 import subprocess
+import logging
+
+log_file = 'manifest-build-tools.log'
+logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', filename=log_file, filemode='w', level=logging.DEBUG)
 
 def strip_suffix(text, suffix):
     """

--- a/manifest-build-tools/lib/common.py
+++ b/manifest-build-tools/lib/common.py
@@ -2,6 +2,8 @@
 
 import subprocess
 import logging
+from pyjavaproperties import Properties
+import os
 
 log_file = 'manifest-build-tools.log'
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', filename=log_file, filemode='w', level=logging.DEBUG)
@@ -18,22 +20,109 @@ def strip_suffix(text, suffix):
     else:
         return text
 
-
 def strip_prefix(text, prefix):
     if text is not None and text.startswith(prefix):
         return text[len(prefix):]
     else:
         return text
 
+def write_parameters(filename, params):
+    """
+    Add/append parameters(java variable value pair) to the given parameter file.
+    If the file does not exist, then create the file.
+    :param filename: The path of the parameter file
+    :param params: the parameters dictionary
+    :return:None on success
+            Raise any error if there is any
+    """
+    if filename is None:
+        raise ValueError("parameter file name is not None")
+    with open(filename, 'w') as fp:
+        for key in params:
+            entry = "{key}={value}\n".format(key=key, value=params[key])
+            fp.write(entry)
+
 def link_dir(src, dest, dir):
     cmd_args = ["ln", "-s", src, dest]
+    run_command(cmd_args, directory=dir)
+
+def get_debian_version(file_path):
+    """
+    Get the version of a debian file
+    :param file_path: the path of the debian file
+    :return: the version of the debian file
+    """
+    cmd_args = ["dpkg-deb", "-f", file_path, "Version"]
+    debian_version = run_command(cmd_args)
+    return debian_version
+
+def get_debian_package(file_path):
+    cmd_args = ["dpkg-deb", "-f", file_path, "Package"]
+    debian_name = run_command(cmd_args)
+    return debian_name
+
+def parse_property_file(filename):
+    """
+    parse java properties file
+    :param filename: the path of the properties file
+    :return: dictionary loaded from the file
+    """
+    if not os.path.isfile(filename):
+        raise RuntimeError("No file found for parameter at {0}".format(filename))
+    p = Properties()
+    p.load(open(filename))
+    return p
+
+def parse_credential_variable(varname):
+    """
+    Get the specified variable name from the environment and split it into username,password
+    :param varname: environment variable name
+    :return: username, password tuple
+    """
+    try:
+        if varname not in os.environ:
+            raise ValueError("Credential variable {0} doesn't exist".format(varname))
+
+        credential = os.environ[varname]
+        if credential is None:
+            raise ValueError("Failed to parse credential variable {0}".format(varname))
+
+        (username, password) = credential.split(':', 2)
+        if username is None or password is None:
+            raise ValueError("Failed to split credential variable {0} into username, password".format(varname))
+
+        return username, password
+    except Exception, e:
+        raise ValueError(e)
+
+def run_command(cmd_args, directory=None):
     proc = subprocess.Popen(cmd_args,
-                            cwd=dir,
                             stderr=subprocess.PIPE,
                             stdout=subprocess.PIPE,
+                            cwd=directory,
                             shell=False)
     (out, err) = proc.communicate()
-    if proc.returncode != 0:
-        raise RuntimeError("Failed to sync {0} to {1} due to {2}".format(src, dest, err))
+    if proc.returncode == 0:
+        return out.strip()
+    else:
+        commandline = " ".join(cmd_args)
+        raise RuntimeError("Failed to run command {0} due to {1}".format(commandline, err))
 
+def find_specify_type_files(directory, suffix, depth=4096):
+    file_list = []
+    top_dir_depth = directory.count(os.path.sep) #How deep is at starting point
+    for root, dirs, files in os.walk(directory):
+        root_depth = root.count(os.path.sep)
+        if (root_depth - top_dir_depth) <= depth:
+            for file_itr in files:
+                if file_itr.endswith(suffix):
+                    abs_file = os.path.abspath(os.path.join(root, file_itr))
+                    file_list.append(abs_file)
+    return file_list
+
+def str2bool(string):
+    if string.lower() in ("true", "yes", "t", "1"):
+        return True
+    else:
+        return False
 

--- a/manifest-build-tools/lib/gitbits.py
+++ b/manifest-build-tools/lib/gitbits.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import tempfile
 from urlparse import urlparse
-
+from common import *
 
 class GitBit(object):
     @staticmethod
@@ -172,7 +172,7 @@ class GitBit(object):
         cmd_args = [self.__git_executable] + config_args + args
 
         if dry_run or self.__verbose:
-            print "GIT: {0}".format(" ".join(cmd_args))
+            logging.warning("GIT: {0}".format(" ".join(cmd_args)))
 
         if dry_run:
             return 0, None, None


### PR DESCRIPTION
Add a script to compute the version of package.

The proposal of manifest build in rackhd release  is [here](https://groups.google.com/forum/#!topic/rackhd/v3LpRuQJvQg).

This PR depends on: https://github.com/RackHD/on-tools/pull/25 ; https://github.com/RackHD/on-tools/pull/26; https://github.com/RackHD/on-tools/pull/28; https://github.com/RackHD/on-tools/pull/29
