### PR TITLE
Fix the issue found when setting up ubuntu iso

### DIFF
--- a/scripts/setup_iso.py
+++ b/scripts/setup_iso.py
@@ -79,9 +79,17 @@ def do_setup_repo(osname, osver, src, dest, link):
 
         shutil.copyfile(src+'/isolinux/'+vmlinuz, dstpath+'/'+vmlinuz)
     elif osname == 'Ubuntu':
-        p = subprocess.Popen(['ls', src], stdout=subprocess.PIPE)
-        filenames = p.stdout.read().split('\n')
-        ignoreList=[f for f in filenames if f == 'ubuntu' or f == '']
+        # Execute 'ls -l' and find out the soft link that points to itself
+        p = subprocess.Popen(['ls', '-l', src], stdout=subprocess.PIPE)
+        files = p.stdout.read().split('\n')
+        ignoreList = list()
+        # The first element is something like "Total 212" and the last element is '', so skip both while finding the softlink
+        # The for loop is to find 'ubuntu' from  a list like   ["lr-xr-xr-x","root","root","ubuntu","->","."]
+        for f in files[1:-1]:
+            f_info = f.split(' ')
+            if 'l'  in f_info[0] and f_info[-2] == '->' and f_info[-1] == '.':
+                ignoreList.append(f_info[-3])
+
         shutil.copytree(src, dstpath, ignore=shutil.ignore_patterns(*ignoreList))
     else:
         shutil.copytree(src, dstpath)


### PR DESCRIPTION
When setting up ubuntu iso, 2 more issues were encountered:
1. The original iso was mounted to /tmp and then copied to the destination the user specifies. However, there is a soft links called ubuntu that point to the iso content itself, so  when coping from /tmp with shutil.copytree(src, dest), it failed with "Too many levels of symbolic links". To fix it, skip the softlink while coping.
2. The Ubuntu iso contains the liveCD, with the existing design, the Ubuntu iso is treated as the Live CD iso, resulting in failure. After changes, if the iso contains both ubuntu and LiveCD, treat it as ubuntu. @RackHD/corecommitters @cgx027 @nortonluo @pengz1 @iceiilin 