### PR TITLE
[W.I.P] Sliced bintray

### DIFF
--- a/manifest-build-tools/lib/sliced_bintray_downloader.sh
+++ b/manifest-build-tools/lib/sliced_bintray_downloader.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+#!/bin/bash
+set -e
+set -x
+###########################################
+# Required ENV Variable
+#############################################
+#SUBJECT=rackhd-mirror
+#REPO=binary
+#PACKAGE=RackHD-Vagrant
+#RACKHD_VER=0.4.2
+#UPLOAD_PATH=vagrant_${RACKHD_VER}
+#BINTRAY_USER=p*****0
+#BINTRAY_API_KEY=35477********************************4
+###########################################
+
+sliced_bintray_download()
+{
+    # ENV PARAM CHECK: T.B.D #FIXME
+    # ...
+
+
+
+    if [[ $(which 7z) == "" ]]
+    then
+        echo "[Error] please install 7z first...Aborting"
+        exit 1
+    fi
+
+
+    # Download the splited files from bintray
+
+    # Parse the Bintray Directory page, extract the sub-files, and append to the URL before wget.
+
+    DOWNLOAD_URL_PREFIX=https://dl.bintray.com/$SUBJECT/$REPO/$UPLOAD_PATH
+    TMP_FILE=flist.txt
+
+    wget  ${DOWNLOAD_URL_PREFIX} -O ${TMP_FILE}
+    # Note , Bintray added an colon ":" before file name in API endpoints. it prevents direct "wget" to download.
+    # we have to escape them first.
+    # so ```grep``` will search for href=":abc.7z.00x" string, then ```sed``` to replace the colon and href=" string.
+    FLIST=$(cat ${TMP_FILE} |grep -o href=\"\:[A-Za-z0-9._\-]\* |sed 's/href=\"\://')
+
+    LOCAL_DOWNLOAD_FOLDER=/tmp/my_tmp
+
+    mkdir -p $LOCAL_DOWNLOAD_FOLDER
+    rm $LOCAL_DOWNLOAD_FOLDER/* -f
+
+    echo $FLIST
+    for f in ${FLIST[@]};
+    do
+        # Download files
+         wget ${DOWNLOAD_URL_PREFIX}/${f} -P $LOCAL_DOWNLOAD_FOLDER
+    done
+
+    # DeCompress the zip files
+    7z e  ${LOCAL_DOWNLOAD_FOLDER}/${FLIST[1]}
+}

--- a/manifest-build-tools/lib/sliced_bintray_uploader.sh
+++ b/manifest-build-tools/lib/sliced_bintray_uploader.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#!/bin/bash
+set -e
+set -x
+############################################
+# Required ENV Variable
+#############################################
+#
+#RACKHD_VER=0.4.2
+#SUBJECT=rackhd-mirror
+#REPO=binary
+#PACKAGE=RackHD-Vagrant
+#UPLOAD_PATH=vagrant_${RACKHD_VER}
+#LOCAL_FILE_PATH=~/RackHD/packer/7z/
+#TARGE_FILE=~/RackHD/packer/rackhd-ubuntu-16.04.ova
+#BINTRAY_USER=p*****0
+#BINTRAY_API_KEY=35477********************************4
+#SLICE_SIZE=200m  # 200MB for each slice, which is Bintray OSS Plan Max per Upload size
+###########################################
+
+sliced_bintray_upload()
+{
+    # ENV PARAM CHECK: T.B.D #FIXME
+    # ...
+
+
+
+    if [[ $(which 7z) == "" ]]
+    then
+        echo "[Error] please install 7z first...Aborting"
+        exit 1
+    fi
+
+    rm -r ${LOCAL_FILE_PATH}
+
+    ## Split the Target file into small pieces (200MB , meet Bintray OSS Plan's max size limitation)
+    7z a -v${SLICE_SIZE} -mx0   ${LOCAL_FILE_PATH}/${PACKAGE}${RACKHD_VER}       ${TARGE_FILE}
+
+
+    for i in $(ls ${LOCAL_FILE_PATH});  do
+       echo $i
+       ../pushToBintray.sh  --user $BINTRAY_USER   --api_key $BINTRAY_API_KEY --subject ${SUBJECT}  --repo  $REPO  --package  $PACKAGE --version ${RACKHD_VER}    --file_path $LOCAL_FILE_PATH/${i}  --target_folder   vagrant_${RACKHD_VER}
+       if [[ ! $? -eq 0 ]]; then
+          echo "[Error] Push To Bintray Failed. Aborting"
+           exit 2
+       fi
+    done
+}
+
+#####
+sliced_bintray_upload


### PR DESCRIPTION
Background

Bintray OSS Plan only allows 200MB per upload.
although Bintray provides handy Vagrant repo functionality, but it's a pity that our box is ~1GB.

before we get fund for a better bintray plan, this is a workaround ...

HOWTO:

1. when uploading, we use ```7z``` to split( no compress) big file into pieces of 200MB for each.
2. when downloading, we can use ```7z``` again to combine them together..

 


@PengTian0 @changev 