### PR TITLE
Support Release: build debian packages parallelly 

### DIFF
--- a/manifest-build-tools/application/make_debian_packages.py
+++ b/manifest-build-tools/application/make_debian_packages.py
@@ -7,10 +7,9 @@ This program build debian packages for repositories
 which checked out based on the given manifest file.
 
 Usage:
-./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/make-debian-release.py \
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/make_debian_packages.py \
 --build-directory b/ \
---manifest-name rackhd-devel \
---manifest-repo build-manifests/ \
+--manifest-file rackhd-devel \
 --git-credential https://github.com,GITHUB \
 --jobs 8 \
 --is-official-release true\
@@ -20,9 +19,7 @@ Usage:
 
 The required parameters:
 build-directory: A directory where all the repositories are cloned to. 
-manifest-name: The name of a manifest file. 
-               All the repositories are cloned based on the manifest file.
-manifest-repo: The directory of manifest repository
+manifest-file: The path of manifest file. 
 git-credential: Git URL and credential for CI services: <URL>,<Credentials>
 
 The optional parameters:
@@ -43,7 +40,7 @@ import json
 
 try:
     from reprove import ManifestActions
-    from update_rackhd_version import RackhdDebianControlUpdater
+    from update_dependencies import RackhdDebianControlUpdater
     from version_generator import VersionGenerator
     from DebianBuilder import DebianBuilder
     import common

--- a/manifest-build-tools/application/make_debian_packages.py
+++ b/manifest-build-tools/application/make_debian_packages.py
@@ -103,6 +103,13 @@ def parse_args(args):
     return parsed_args
 
 def update_rackhd_control(top_level_dir, is_official_release):
+    """
+    Update the rackhd/debian/control with the version of on-xxx.deb under $top_level_dir.
+    :param top_level_dir: Top level directory that stores all the
+                          cloned repositories.
+    :param is_official_release: If true, this release is official release
+    :return: None
+    """
     updater = RackhdDebianControlUpdater(top_level_dir, is_official_release)
     updater.update_RackHD_control()
 

--- a/manifest-build-tools/application/make_debian_packages.py
+++ b/manifest-build-tools/application/make_debian_packages.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# Copyright 2016, DELLEMC, Inc.
+
+"""
+This is a command line program that makes a rackhd release to bintray.
+This program build debian packages for repositories 
+which checked out based on the given manifest file.
+
+Usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/make-debian-release.py \
+--build-directory b/ \
+--manifest-name rackhd-devel \
+--manifest-repo build-manifests/ \
+--git-credential https://github.com,GITHUB \
+--jobs 8 \
+--is-official-release true\
+--parameter-file downstream-files \
+--force \
+--sudo-credential SUDO_CREDS
+
+The required parameters:
+build-directory: A directory where all the repositories are cloned to. 
+manifest-name: The name of a manifest file. 
+               All the repositories are cloned based on the manifest file.
+manifest-repo: The directory of manifest repository
+git-credential: Git URL and credential for CI services: <URL>,<Credentials>
+
+The optional parameters:
+is-official-release: Whether this release is official. The default value is False
+parameter-file: The file with parameters. The file will be passed to downstream jobs.
+force: Use destination directory, even if it exists.
+sudo-credential: The environment variable name of sudo credentials.
+                 For example: SUDO_CRED=username:password
+jobs: Number of parallel jobs(build debian packages) to run.
+      The number is related to the compute architecture, multi-core processors..
+force:
+"""
+
+import argparse
+import os
+import sys
+import json
+
+try:
+    from reprove import ManifestActions
+    from update_rackhd_version import RackhdDebianControlUpdater
+    from version_generator import VersionGenerator
+    from DebianBuilder import DebianBuilder
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--build-directory',
+                        required=True,
+                        help="Top level directory that stores all the cloned repositories.",
+                        action='store')
+
+    parser.add_argument('--manifest-file',
+                        required=True,
+                        help="The file path of manifest",
+                        action='store')
+
+    parser.add_argument('--parameter-file',
+                        help="The jenkins parameter file that will used for succeeding Jenkins job",
+                        action='store',
+                        default="downstream_parameters")
+
+    parser.add_argument('--git-credential',
+                        required=True,
+                        help="Git URL and credential for CI services: <URL>,<Credentials>",
+                        action='append',
+                        default=None)
+
+    parser.add_argument('--sudo-credential',
+                        help="username:password pair for sudo user",
+                        action='store',
+                        default=None)
+
+    parser.add_argument('--jobs',
+                        help="Number of build jobs to run in parallel",
+                        default=-1,
+                        type=int,
+                        action="store")
+
+    parser.add_argument('--is-official-release',
+                        default="false",
+                        help="Whether this release is official",
+                        action="store")
+
+    parser.add_argument('--force',
+                        help="Overwrite a directory even if it exists",
+                        action="store_true")
+
+    parsed_args = parser.parse_args(args)
+    parsed_args.is_official_release = common.str2bool(parsed_args.is_official_release)
+    return parsed_args
+
+def update_rackhd_control(top_level_dir, is_official_release):
+    updater = RackhdDebianControlUpdater(top_level_dir, is_official_release)
+    updater.update_RackHD_control()
+
+def generate_version_file(repo_dir, is_official_release):
+    """
+    Generate the version file for rackhd repository
+    :param repo_dir: The directory of rackhd repository
+    :param is_official_release: If true, this release is official release
+    :return: True if succeed to compute version and write it into version file.
+             Otherwise, False.
+    """
+    try:
+        version_generator = VersionGenerator(repo_dir)
+        version = version_generator.generate_package_version(is_official_release)
+        if version != None:
+            params = {}
+            params['PKG_VERSION'] = version
+            repo_name = os.path.basename(repo_dir)
+            version_file = "{0}.version".format(repo_name)
+            version_path = os.path.join(repo_dir, version_file)
+            common.write_parameters(version_path, params)
+            return True
+    except Exception, e:
+        raise RuntimeError("Failed to generate version file for {0} \ndue to {1}".format(repo_dir, e))
+
+def run_build_scripts(top_level_dir, repos, jobs=1, sudo_creds=None):
+    """
+    Go into the directory provided and run all the building scripts.
+    :param top_level_dir: Top level directory that stores all the
+                          cloned repositories.
+    :param repos: A list of repositories to be build
+    :param jobs: Number of parallel jobs(build debian packages) to run.
+    :param sudo_creds: the environment variable name of sudo credentials.
+                       for example: SUDO_CRED=username:password
+    :return:
+        exit on failures
+        None on success.
+    """
+    try:
+        builder = DebianBuilder(top_level_dir, repos, jobs=jobs, sudo_creds=sudo_creds)
+        builder.blind_build_all()
+        builder.print_summary_report()
+        builder.print_detailed_report()
+        result = builder.get_build_result()
+        if result:
+            print "Debian building is finished successfully."
+        else:
+            #builder.print_detailed_report()
+            print "Error found during debian building. cannot continue."
+            sys.exit(2)
+    except Exception, e:
+        sys.exit(1)
+
+def get_build_repos(directory):
+    """
+    :param directory: Directory that stores all the cloned repositories.
+    :return: a list which contains the name of repositories under the directory
+    """
+    repos = []
+    for filename in os.listdir(directory):
+        repos.append(filename)
+    return repos
+
+def checkout_repos(manifest, builddir, force, git_credential, jobs):
+    try:
+        manifest_actions = ManifestActions(manifest, builddir, force=force, git_credentials=git_credential, jobs=jobs, actions=["checkout", "packagerefs"])
+        manifest_actions.execute_actions()
+    except Exception, e:
+        print "Failed to checkout repositories according to manifest file {0} \ndue to {1}. Exiting now...".format(manifest, e)
+        sys.exit(1)
+
+def build_debian_packages(build_directory, jobs, is_official_release, sudo_creds):
+    """
+    Build debian packages
+    """
+    try:
+        repos = get_build_repos(build_directory)
+        for repo in repos:
+            repo_dir = os.path.join(build_directory, repo)
+            generate_version_file(repo_dir, is_official_release)
+
+        # Build Debian packages of repositories except RackHD
+        repos.remove("RackHD")
+        # Run HWIMO-BUILD script under each repository to build debian packages
+        run_build_scripts(build_directory, repos, jobs=jobs, sudo_creds=sudo_creds)
+
+        # If on-xxx.deb build successfully, build Debian packages of RackHD
+        repos = ["RackHD"]
+        # Update the debian/control of rackhd to depends on specified version of component of raqkhd
+        update_rackhd_control(build_directory, is_official_release)
+        # Run HWIMO-BUILD script under each repository to build debian packages
+        run_build_scripts(build_directory, repos, sudo_creds=sudo_creds)
+
+    except Exception, e:
+        print "Failed to build debian packages under {0} \ndue to {1}, Exiting now".format(build_directory, e)
+        sys.exit(1)
+
+def write_downstream_parameter_file(build_directory, is_official_release, parameter_file):
+    try:
+        params = {}
+
+        # Add rackhd version to downstream parameters
+        rackhd_repo_dir = os.path.join(build_directory, "RackHD")
+        version_generator = VersionGenerator(rackhd_repo_dir)
+        rackhd_version = version_generator.generate_package_version(is_official_release)
+        if rackhd_version != None:
+            params['RACKHD_VERSION'] = rackhd_version
+        else:
+            raise RuntimeError("Version of {0} is None. Maybe the repository doesn't contain debian directory ".format(rackhd_repo_dir))
+
+        # Write downstream parameters to downstream parameter file.
+        common.write_parameters(parameter_file, params)
+    except Exception, e:
+        raise RuntimeError("Failed to generate version file for {0} \ndue to {1}".format(repo_dir, e))
+
+def main():
+    """
+    Build all the debians.
+    Exit on encountering any error.
+    """
+    args = parse_args(sys.argv[1:])
+    checkout_repos(args.manifest_file, args.build_directory, args.force, args.git_credential, args.jobs)
+    build_debian_packages(args.build_directory, args.jobs, args.is_official_release, args.sudo_credential)
+    write_downstream_parameter_file(args.build_directory, args.is_official_release, args.parameter_file)
+
+if __name__ == '__main__':
+    main()

--- a/manifest-build-tools/lib/Builder.py
+++ b/manifest-build-tools/lib/Builder.py
@@ -1,0 +1,344 @@
+# Copyright 2016, DELLEMC, Inc.
+"""
+This is a module that contains the tool for python to run a list of commands
+and generate report for results of running.
+"""
+
+import os
+import subprocess
+import sys
+
+try:
+    from ParallelTasks import ParallelTasks
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class BuildResult(object):
+    """
+    Complete output from the running of a build command on a given host.
+    Contains the command that was supposed to be run, whether it was present ot not,
+    the return code, and the standard output and standard error text.
+    """
+    def __init__(self, command, present, return_code=None, stdout=None, stderr=None):
+        self._command = command
+        self._present = present
+
+        self._return_code = return_code
+        self._stdout = stdout
+        self._stderr = stderr
+
+    @property
+    def command(self):
+        return self._command
+
+    @command.setter
+    def command(self, command):
+        self._command = command
+
+    @property
+    def present(self):
+        return self._present
+
+    @present.setter
+    def present(self, present):
+        self._present = present
+
+    @property
+    def return_code(self):
+        return self._return_code
+
+    @return_code.setter
+    def return_code(self, return_code):
+        self._return_code = return_code
+
+    @property
+    def stdout(self):
+        return self._stdout
+
+    @stdout.setter
+    def stdout(self, stdout):
+        self._stdout = stdout
+
+    @property
+    def stderr(self):
+        return self._stderr
+
+    @stderr.setter
+    def stderr(self, stderr):
+        self._stderr = stderr
+
+    def generate_detailed_report(self):
+        """
+        Generate reports with details: return code, stdout, stderr
+        """
+        detailed = []
+        if self._present is True:
+            detailed.append(self._command)
+            if self._return_code != 0:
+                detailed.append("  ERROR: EXIT {0}".format(self._return_code))
+                if self._stdout is not None and self._stdout != "":
+                    detailed.append(self._stdout)
+                if self._stderr is not None and self._stderr != "":
+                    detailed.append(self._stderr)
+
+        return detailed
+
+    def generate_summary_report(self):
+        """
+        Generate report with the result of running: 
+        Good or ERROR: EXIT or Not Present
+        """
+        summary = []
+        short_command = os.path.basename(self._command)
+        if self._present is True:
+            if self._return_code is not None:
+                if self._return_code == 0:
+                    status = "GOOD"
+                else:
+                    status = "ERROR: EXIT {0}".format(self._return_code)
+            else:
+                status = "RETURN CODE IS NONE"
+        else:
+            status = " Not Present"
+        summary.append("    {0}: {1}".format(short_command, status))
+        return summary
+
+    @staticmethod
+    def summarize_errors(results):
+        errors = 0
+        for result in results:
+            if result.return_code != 0:
+                errors += 1
+        return errors
+
+class BuildCommand(object):
+    """
+    A module for build command.
+    """
+    def __init__(self, name, directory, arguments=None, use_sudo=False, sudo_creds=None):
+        """
+        _name: the command name that was supposed to be run
+        _directory: the directory under which to run command
+        _use_sudo: whether the command was run with sudo previleges
+        _sudo_creds: the environment variable name of sudo credentials. 
+                     For example: SUDO_CREDS=username:password
+        _arguments: the arguments of the command
+        """
+        self._name = name
+        self._directory = directory
+        self._use_sudo = use_sudo
+        self._sudo_creds = sudo_creds
+        self._arguments = arguments
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name
+
+    @property
+    def directory(self):
+        return self._directory
+
+    @directory.setter
+    def directory(self, directory):
+        self._directory = directory
+
+    @property
+    def use_sudo(self):
+        return self._use_sudo
+
+    @use_sudo.setter
+    def use_sudo(self, use_sudo):
+        self._use_sudo = use_sudo
+
+    @property
+    def sudo_creds(self):
+        return self._sudo_creds
+
+    @sudo_creds.setter
+    def sudo_creds(self, sudo_creds):
+        self._sudo_creds = sudo_creds
+        
+    def to_string(self):
+        cmd_args = []
+        if self._use_sudo:
+            if self._sudo_creds is None:
+                raise ValueError("sudo credential missing from commands {0}".format(name))
+            (username, password) = common.parse_credential_variable(self._sudo_creds)
+            cmd_args += ["echo"]
+            cmd_args += [password]
+            cmd_args += ["|sudo -S"]
+
+        cmd_args += [self._name]
+
+        if self._arguments:
+            cmd_args += self._arguments
+
+        command_str = " ".join(cmd_args)
+        return command_str
+
+    def run(self):
+        try:
+            command = self.to_string()
+            print "Execute command: {0} under {1}".format(command, self._directory)
+            proc = subprocess.Popen(command,
+                                    stderr=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    cwd=self._directory,
+                                    shell=True)
+            (out, err) = proc.communicate()
+        except Exception, ex:
+            # this is a terrible failure, not just process exit != 0
+            return BuildResult(self._name,
+                               present=True,
+                               return_code=1,
+                               stderr=ex)
+
+        result = BuildResult(self._name,
+                             present=True,
+                             return_code=proc.returncode,
+                             stdout=out,
+                             stderr=err)
+        return result
+
+    def is_executable(self):
+        exe_file = os.path.join(self._directory, self._name)
+        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
+            return True
+
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
+                return True
+
+        return False
+
+class Builder(ParallelTasks):
+    """
+    Run a list of command under a directory.
+
+    This class is intended for use with ParallelTasks, and each commands list may be done
+    in a separate process.
+
+    """
+    def add_task(self, data, name):
+        """
+        Add a task to task queue
+        :param data: A dictonary which should contain:
+                     commands: A list of comamnd instances. It's required.
+                     env_file: A property file which contains environment variables. It's optional
+        :param name: The name of the task. The key by which the job results will be returned.
+        :return: None
+        """
+        if data is None:
+            raise ValueError("Task parameter data not present")
+
+        if 'commands' not in data:
+            raise ValueError("commands key missing from data: {0}".format(data))
+
+        super(Builder, self).add_task(data, name)
+
+    @staticmethod
+    def initail_environment(env_file):
+        print "start to export environment file {0}".format(env_file)
+        if not os.path.isfile(env_file):
+            raise RuntimeError("Failed to initial environment due to the file {0} doesn't exist"
+                               .format(env_file))
+        props = common.parse_property_file(env_file)
+        if props:
+            for item in props.items():
+                key = item[0]
+                value = item[1]
+                os.environ[key] = value
+
+    def do_one_task(self, name, data, results):
+        """
+        Perform the actual work.
+        name and data will come from the values passed in to add_task()
+        :param results: a list of instances of BuildResult
+        :return: None
+        """
+        try:
+            if 'command' not in results:
+                results['command'] = []
+
+            if 'env_file' in data and data['env_file'] is not None:
+                self.initail_environment(data['env_file'])
+
+            for command in data['commands']:
+                if not command.is_executable():
+                    build_result = BuildResult(command, present=False)
+                build_result = command.run()
+                if build_result is not None:
+                    results['command'].append(build_result)
+
+        except Exception, e:
+            raise RuntimeError("Failed to do task {0} due to {1}".format(name, e))
+
+    def summarize_results(self):
+        """
+        :return: True if the number of errors found is 0
+                 False if the number of errors found is greater than 0
+        """
+        results = self.get_results()
+        key_list = results.keys()
+
+        for name in sorted(key_list):
+            if 'command' in results[name]:
+                build_results = results[name]['command']
+                errors = BuildResult.summarize_errors(build_results)
+                if errors > 0:
+                    return False
+        return True
+
+    def generate_detailed_report(self):
+        """
+        Generate reports with details: return code, stdout, stderr
+        """
+        all_detailed = []
+        results = self.get_results()
+        key_list = results.keys()
+        for name in sorted(key_list):
+            if 'command' in results[name]:
+                task_detailed = []
+                task_detailed.append("=== Results for {0} ===".format(name))
+                for result in results[name]['command']:
+                    detailed = result.generate_detailed_report()
+                    task_detailed.extend(detailed)
+
+                all_detailed.extend(task_detailed)
+        return all_detailed
+
+    def generate_summary_report(self):
+        """
+        Generate report with the result of running:
+        Good or ERROR: EXIT or Not Present
+        """       
+        all_summary = []
+
+        results = self.get_results()
+        key_list = results.keys()
+
+        for name in sorted(key_list):
+            if 'command' in results[name]:
+                task_summary = []
+                task_summary.append("{0}:".format(name))
+                build_results = results[name]['command']
+                errors = BuildResult.summarize_errors(build_results)
+                if errors > 0:
+                    task_summary.append("    Number of falied commands: {0}".format(errors))
+
+                for result in build_results:
+                    summary = result.generate_summary_report()
+                    task_summary.extend(summary)
+
+                all_summary.extend(task_summary)
+
+        return all_summary
+

--- a/manifest-build-tools/lib/DebianBuilder.py
+++ b/manifest-build-tools/lib/DebianBuilder.py
@@ -1,0 +1,139 @@
+"""
+This is a module that contains the tool for python to build the
+debians after all the directories are checked out based on a given manifest file.
+"""
+# Copyright 2016, EMC, Inc.
+
+import os
+import subprocess
+import sys
+
+try:
+    from Builder import Builder
+    from Builder import BuildCommand
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class DebianBuilder(object):
+    """
+    This is a class that builds the debian packages. 
+    It assumes that the repository is cloned successfully and is accessible for the tool.
+    """
+    def __init__(self, top_level_dir, repos, jobs=1, sudo_creds=None):
+        """
+        :param top_level_dir: the directory that holds all the cloned
+                              repositories according to manifest
+                              example: <top_level_dir>/on-http/...
+                                                      /on-tftp/...
+        :param repos: a list of repositories to be build
+        :param jobs: Number of parallel jobs(build debian packages) to run.
+        :param sudo_creds: the environment variable name of sudo credentials.
+                           for example: SUDO_CRED=username:password
+        :return: None
+        """
+        self.top_level_dir = top_level_dir
+        self._repos = repos
+        self._jobs = jobs
+        self._sudo_creds = sudo_creds
+        self._builder = Builder(self._jobs)        
+
+    @property
+    def top_level_dir(self):
+        return self._top_level_dir
+
+    @top_level_dir.setter
+    def top_level_dir(self, top_level_dir):
+        """
+        Setter for the repository directory
+        :param top_level_dir: the directory that holds all the cloned
+                              repositories according to manifest
+                              example: <top_level_dir>/on-http/...
+                                                      /on-tftp/...
+        :return: None
+        """
+        if os.path.isdir(top_level_dir):
+            self._top_level_dir = os.path.abspath(top_level_dir)
+        else:
+            raise ValueError("The path provided '{dir}' is not a directory."
+                             .format(dir=top_level_dir))
+
+    def generate_tasks(self):
+        """
+        Generate a list of tasks to be perform.
+        An example of task:
+                   {
+                    'name': repo,
+                    'data': {
+                             'commands': [command1, ...], #command1 is an instance of BuildCommand
+                             'env_file': on-http.version
+                            }
+                   }
+        
+        """
+        tasks = []
+        for repo in self._repos:
+            task = {
+                    'name': repo,
+                    'data': {
+                             'commands': [],
+                             'env_file': None
+                            }
+                   }
+            command_name = './HWIMO-BUILD'
+            path = os.path.abspath(os.path.join(self._top_level_dir, repo))
+            if not os.path.exists(path):
+                raise ValueError("Repository {0} doesn't exist under {1}"
+                                 .format(repo, self._top_level_dir))
+            command = BuildCommand(command_name, path)
+            if repo == "on-imagebuilder" and self._sudo_creds:
+                command.use_sudo = True
+                command.sudo_creds = self._sudo_creds
+            task['data']['commands'].append(command)
+
+            version_file = "{0}.version".format(repo)
+            version_path = os.path.abspath(os.path.join(path, version_file))
+            if os.path.exists(version_path):
+                task['data']['env_file'] = version_path
+            tasks.append(task)
+
+        return tasks
+
+    def blind_build_all(self):
+        """
+        Iterate through the first layer subdirectory of top_level_dir and
+        if found HWIMO-BUILD, then execute the script.
+        """
+        try:
+            tasks = self.generate_tasks()
+            for task in tasks:
+                self._builder.add_task(task['data'], task['name'])
+            self._builder.finish()
+        except Exception, e:
+            raise RuntimeError("Failed to build all debian packages due to \n{0}".format(e))
+
+    def get_build_result(self):
+        """
+        If all the tasks success, then return true,
+        otherwise return false
+        :return: True if build success.
+                 False if build failed.
+        """
+        build_result = self._builder.summarize_results()
+        return build_result
+
+    def print_detailed_report(self):
+        detailed = self._builder.generate_detailed_report()
+        print "\n\nvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n\n"
+        print "Full Details\n"
+        for item in detailed:
+            print item
+
+    def print_summary_report(self):
+        summary = self._builder.generate_summary_report()
+        print "\n\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n"
+        print "Summary:"
+        for item in summary:
+            print item
+        print "\n\n"
+


### PR DESCRIPTION
**Background**
One of the step of release is building debian packages.
This PR is used to implement the step.

**Implementation**
1. check out repositories according to a mainfest file.
2. run ```HWIMO-BUILD``` script under on-xxx repositories to build on-xxx.deb packages in parallel.
3. update debian/control of RackHD with the version of on-xxx.deb.
    In this way, RackHD.deb depends on the specify version of on-xxx.deb
4. run ```HWIMO-BUILD``` script under RackHD to build RackHD.deb

**Test**
The test jenkins job:
http://rackhdci.lss.emc.com/job/Maglev-BRI-Test/job/release/job/MBU1/
