### PR TITLE
docker build support new release/build requirments

### DIFF
--- a/manifest-build-tools/docker_build.sh
+++ b/manifest-build-tools/docker_build.sh
@@ -1,25 +1,47 @@
-#!/bin/bash
+#!/bin/bash 
+set -e
 
 #
 # This script is for build/push rackhd docker images.
 # Environmental requirement:
-#   1.docker service running and docker have already logged with Rackhd Dockerhub ID, 
-#     cmd 'docker login', if not logged then can't push images to dockerhub
-#   2.A sources.list to replace default sources.list of nodesource/wheezy:4.4.6 image(the root image which on-core pulled)
+#   1.A sources.list to replace default sources.list of nodesource/wheezy:4.4.6 image(the root image which on-core pulled)
 #     http://httpredir.debian.org/debiani(not stable for EMC network.) -> http://ftp.us.debian.org/debian
 # Parameters:
 #   ${1}, WORKDIR, default: ../../, a absolute where all repos are cloned
-#   ${2}, DEVEL, default: false, a bool value indicate if is building on master branch
+#   ${2}, IS_OFFICIAL_RELEASE, default: false, a bool value indicates if is building release
+
 
 #when run this script locally use default value
 WORKDIR=${1}
 BASEDIR=$(cd $(dirname "$0");pwd)
 WORKDIR=${WORKDIR:=$(dirname $(dirname $BASEDIR))}
 
-DEVEL=${2}
-DEVEL=${DEVEL:=false}
+IS_OFFICIAL_RELEASE=${2}
+IS_OFFICIAL_RELEASE=${IS_OFFICIAL_RELEASE:=false}
 
-DEFAULT_VERSION=test
+tagCalculate() {
+    repo=$1
+    #Get package version from debian/changelog
+    if [ -f "debian/changelog" ]; then
+        CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+    elif [ -f "debianstatic/$repo/changelog" ]; then
+        cp -rf debianstatic/$repo ./debian
+        CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+        rm -rf debian
+    else
+        CHANGELOG_VERSION=$RACKHD_CHANGELOG_VERSION
+    fi
+    
+    #generate real TAG
+    if [ "$IS_OFFICIAL_RELEASE" == "true" ]; then
+        PKG_TAG="$CHANGELOG_VERSION"
+    else
+        GIT_COMMIT_DATE=$(git show -s --pretty="format:%ci")
+        DATE_STRING="$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%SZ")UTC"
+        GIT_COMMIT_HASH=$(git show -s --pretty="format:%h")
+        PKG_TAG="$CHANGELOG_VERSION-$DATE_STRING-$GIT_COMMIT_HASH"
+    fi
+}
 
 doBuild() {
     # List order is important, on-tasks image build is based on on-core image, 
@@ -27,7 +49,9 @@ doBuild() {
     # others are based on on-core image
     repos=$(echo "on-core on-syslog on-dhcp-proxy on-tftp on-wss on-statsd on-tasks on-taskgraph on-http")
     #Record all repo:tag for post-pushing
-    repos_versions=""
+    repos_tags=""
+    #Set an empty TAG before each build
+    TAG=""
     #For relpacing the unstable wheezy official source
     SOURCE_LIST=https://raw.githubusercontent.com/RackHD/on-tools/master/manifest-build-tools/docker_sources.list
     for repo in $repos;do
@@ -37,51 +61,62 @@ doBuild() {
             exit 1
         fi
         pushd $repo
-            PKG_VERSION=""
+            PKG_TAG=""
             if [ "$BUILD_LATEST" != true ]; then
-                #use the provided version number if exists in .version
-                PKG_VERSION=$(source ./.version && PKG_VERSION=${PKG_VERSION//\~/-} && echo $PKG_VERSION)
-                VERSION=:${PKG_VERSION:=$DEFAULT_VERSION}
+                tagCalculate $repo
+                TAG=:${PKG_TAG}
             fi
-            echo "Building rackhd/$repo$VERSION"
-            repos_versions=$repos_versions$repo$VERSION" "
+            echo "Building rackhd/$repo$TAG"
+            repos_tags=$repos_tags$repo$TAG" "
             cp Dockerfile ../Dockerfile.bak
             if [ "$repo" != "on-core" ];then
                     # Use the new sources.list
-                    sed -i "/^FROM/a RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak\nCOPY $SOURCE_LIST /etc/apt/sources.list" Dockerfile
+                    sed -i "/^FROM/a RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak\nADD $SOURCE_LIST /etc/apt/sources.list" Dockerfile
                     #Based on newly build upstream image to build
-                    sed -i "/^FROM/ s/$/${PRE_VERSION}/" Dockerfile
+                    sed -i "/^FROM/ s/$/${PRE_TAG}/" Dockerfile
                     # Recover the sources.list
                     sed -i -e "\$aRUN mv /etc/apt/sources.list.bak /etc/apt/sources.list" Dockerfile
-                    docker build -t rackhd/$repo$VERSION .
+                    docker build -t rackhd/$repo$TAG .
             fi
             case $repo in
                 "on-core")
-                    docker build -t rackhd/$repo$VERSION .
-                    PRE_VERSION=$VERSION
+                    docker build -t rackhd/$repo$TAG .
+                    PRE_TAG=$TAG
                     ;;
                 "on-tasks")
-                    PRE_VERSION=$VERSION
+                    PRE_TAG=$TAG
                     ;;
             esac 
             mv ../Dockerfile.bak Dockerfile
         popd
     done
 
-    # Push all newly build images to Dockerhub
-    for repo_version in $repos_versions;do
-        echo "Pushing rackhd/$repo_version "
-        docker push rackhd/$repo_version
-    done
+    # write build list to a file for guiding image push. 
+    pushd $WORKDIR
+    echo "Imagename:tag list of this build is $repos_tags"
+    echo $repos_tags >> build_record
+    popd
 }
 
 # Build begins
 pushd $WORKDIR
+
+pushd RackHD
+    #get rackhd changelog Version
+    RACKHD_CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+popd
+
+#record all image:tag of each build
+if [ -f build_record ];then
+    rm build_record
+    touch build_record
+fi
+
 doBuild
-if [[ "$DEVEL" == true ]];then
+if [[ "$IS_OFFICIAL_RELEASE" == true ]];then
     # latest tag is for master branch build.
     BUILD_LATEST=true
     doBuild
 fi
-popd
 # Build ends
+popd

--- a/manifest-build-tools/docker_build.sh
+++ b/manifest-build-tools/docker_build.sh
@@ -37,7 +37,7 @@ tagCalculate() {
         PKG_TAG="$CHANGELOG_VERSION"
     else
         GIT_COMMIT_DATE=$(git show -s --pretty="format:%ci")
-        DATE_STRING="$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%SZ")UTC"
+        DATE_STRING="$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%S")UTC"
         GIT_COMMIT_HASH=$(git show -s --pretty="format:%h")
         PKG_TAG="$CHANGELOG_VERSION-$DATE_STRING-$GIT_COMMIT_HASH"
     fi


### PR DESCRIPTION
This PR is for supporting new release/build requirments(daily build and new release strategy)

* add new version number(tag) calculation
* remove push steps but add a ```record_file``` to save all build information for post-pushing

related jenkins job:
http://10.240.19.21/job/Build-Release/job/docker-build/
built successfully

@panpan0000 @PengTian0 