### PR TITLE
Add script for tag monitor

### DIFF
--- a/manifest-build-tools/application/tag_change_monitor.py
+++ b/manifest-build-tools/application/tag_change_monitor.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# Copyright 2016, EMC, Inc.
+
+"""
+This is a command line program that monitor repos tag updates.
+When new tag appears, this script will write a property file contains new tag information.
+So a record file which stored history tags in each line is necessary.
+
+usage:
+    ./on-tools/manifest-build-tools/HWIMO-BUILD.py \
+    on-tools/manifest-build-tools/application/tag_change_monitor.py \
+    --repo rackhd/on-http \
+    --history_file workspace/on-http_tag_history
+    --property_file workspace/property_file
+
+The required parameters:
+    repo: user_name/repo_name that indicates which repo should be monitoring.
+    history_file: A file stored one history tag in each line. If doesn't exists it will be created.
+    property_file: A file used for downstream job.
+"""
+
+import os
+import sys
+import argparse
+import requests
+
+class TagChangeMonitor(object):
+    """
+    A simple class that monitor repo tag updates.
+    One monitor for one repo.
+    """
+    def __init__(self, repo, history_file, property_file):
+        self.api_url = "https://api.github.com"
+        self.repo = repo
+        self.history_file = history_file
+        self.property_file = property_file
+
+        self.history = {}
+        self.new_history = {}
+        self.change = {}
+
+        if os.path.isfile(history_file):
+            with file(history_file, 'r') as f:
+                for tag_commit in f.readlines():
+                    commit = tag_commit.split()[0]
+                    tags = tag_commit.split()[1:]
+                    self.history[commit] = tags
+                f.close()
+        else:
+            with file(history_file, 'w') as f:
+                f.close()
+
+    def handle_tag_monitor(self):
+        """
+        Do tag monitor job
+        """
+        tag_list = self.get_tags()
+        self.parse_tag_info(tag_list)
+        if self.change:
+            self.write_property_file()
+        self.write_history_file()
+
+    def get_tags(self):
+        """
+        Get all tags of current repo.
+        """
+        list_tag_url = "/".join([self.api_url, "repos", self.repo, "tags"])
+        resp = requests.get(list_tag_url)
+        if resp.ok:
+            return resp.json()
+        else:
+            print "Get tags of repo {0} error.\n{1}".format(self.repo, resp.text)
+            sys.exit(1)
+
+    def parse_tag_info(self, tag_list):
+        """
+        Get tag change and generate new tag history record.
+        """
+        find_change = False
+        contains_in_new = True
+        for tag in tag_list:
+            tag_name = tag['name']
+            commit = tag['commit']['sha']
+
+            if (not self.history.has_key(commit)) or \
+                (tag_name not in self.history[commit]):
+                if not find_change:
+                    self.change[commit] = [tag_name]
+                    find_change = True
+                else:
+                    contains_in_new = False
+
+            if contains_in_new:
+                if self.new_history.has_key(commit):
+                    self.new_history[commit].append(tag_name)
+                else:
+                    self.new_history[commit] = [tag_name]
+            else:
+                contains_in_new = True
+
+    def write_history_file(self):
+        """
+        Write new_history to history_file
+        This can keep history file valid when deleting tags.
+        """
+        with file(self.history_file, 'w') as history_file_handler:
+            for commit, tags in self.new_history.iteritems():
+                tags.insert(0, commit)
+                tags.append('\n')
+                history_file_handler.write(" ".join(tags))
+
+    def write_property_file(self):
+        """
+        write property file for downstream job
+        """
+        with file(self.property_file, 'w') as property_file_handler:
+            for commit, tags in self.change.iteritems():
+                output = ""
+                output += "tag_name={0}\n".format(tags[0])
+                output += "commit={0}\n".format(commit)
+                output += "repository=https://github.com/{0}.git".format(self.repo)
+                property_file_handler.write(output)
+
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--repo',
+                        required=True,
+                        help="Indicates the repo",
+                        action='store')
+
+    parser.add_argument('--history_file',
+                        help="File stored tag history",
+                        action='store')
+
+    parser.add_argument('--property_file',
+                        help="Downstream file to use",
+                        action='store')
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+def main():
+    """
+    Monitor tag change of on repo
+    """
+    try:
+        args = parse_args(sys.argv[1:])
+        tcm = TagChangeMonitor(args.repo, args.history_file, args.property_file)
+        tcm.handle_tag_monitor()
+    except Exception, e:
+        print e
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/manifest-build-tools/application/tag_change_monitor.py
+++ b/manifest-build-tools/application/tag_change_monitor.py
@@ -17,7 +17,12 @@ usage:
 The required parameters:
     repo: user_name/repo_name that indicates which repo should be monitoring.
     history_file: A file stored one history tag in each line. If doesn't exists it will be created.
-    property_file: A file used for downstream job.
+    property_file: A file used for downstream job. It's format is like this:
+                  tag_name=release/1.2.3
+                  commit=fb47e10......
+                  repository=https://github.com/RackHD/......
+                  Contains the newly added tags (comparing with the $hsitory_file), with those tags' 
+                  corresponding commit/repository"
 
 The optional parameters:
     credential, A env var name which stores user:password of github.
@@ -124,7 +129,8 @@ class TagChangeMonitor(object):
 
     def write_property_file(self):
         """
-        write property file for downstream job
+        For those tags "newly" detected for this run, write those tags' 
+        information into a property file ( being used by downstream Jenkins job )
         """
         with file(self.property_file, 'w') as property_file_handler:
             for commit, tags in self.change.iteritems():


### PR DESCRIPTION
This script is for tag monitoring.
It based on a tag-commit history_file and output a property file if there's any changes of tags. 

* When push a tag to a commit, if tag:commit pair never appears before,  tag monitor will catch this change and output a property file.
* There'll be no output when finding deleting tag, only history_file will be updated.
* Tag monitor runs periodically, so if do deleting a tag and pushing a same tag to the commit in one interval, tag monitor won't find any change.

@panpan0000 @PengTian0 
