### PR TITLE
Fix: parameters in dict failed to be set

### DIFF
--- a/manifest-build-tools/application/release_debian_packages.py
+++ b/manifest-build-tools/application/release_debian_packages.py
@@ -46,11 +46,32 @@ class Bintray(object):
         self._subject = subject
         self._repo = repo
         self._push_executable = push_executable
-        self._component = None
-        self._distribution = None
-        self._architecture = None
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+    @property
+    def component(self):
+        return self._component
+
+    @component.setter
+    def component(self, component):
+        self._component = component
+
+    @property
+    def distribution(self):
+        return self._distribution
+
+    @distribution.setter
+    def distribution(self, distribution):
+        self._distribution = distribution
+
+    @property
+    def architecture(self):
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        self._architecture = architecture
 
     def upload_a_file(self, package, version, file_path):
         """


### PR DESCRIPTION
**Background**:
The script release_debian_packages.py is used to upload debian packages to bintray.
It accepts parameters:
```--build-directory 
--bintray-credential 
--bintray-subject
--bintray-repo 
--bintray-component 
--bintray-distribution 
--bintray-architecture 
--debian-depth 
```

But the 3 parameters ```bintray-component,  bintray-distribution, bintray-architecture ``` always use their default value.

**Cause**: 
The 3 parameters are optional. So they are passed in a dictionay and use ```setattr``` to initial an instance of Bintray.

The method ```setattr``` only take effects on parameters which have ```setter```.

**Test**:
http://rackhdci.lss.emc.com/job/BuildRelease/job/Release/job/Release

@panpan0000 @changev 