### PR TITLE
add rackhd commit to downstream parameter file

### DIFF
--- a/manifest-build-tools/application/make_debian_packages.py
+++ b/manifest-build-tools/application/make_debian_packages.py
@@ -218,7 +218,9 @@ def write_downstream_parameter_file(build_directory, manifest_file, is_official_
         else:
             raise RuntimeError("Version of {0} is None. Maybe the repository doesn't contain debian directory ".format(rackhd_repo_dir))
 
+        # Add the commit of repository RackHD/RackHD to downstream parameters
         manifest = Manifest(manifest_file)
+        # commit of repository RackHD/RackHD
         rackhd_commit = ''
         for repo in manifest.repositories:
             repository = repo['repository'].lower()

--- a/manifest-build-tools/application/make_debian_packages.py
+++ b/manifest-build-tools/application/make_debian_packages.py
@@ -40,6 +40,7 @@ import json
 
 try:
     from reprove import ManifestActions
+    from manifest import Manifest
     from update_dependencies import RackhdDebianControlUpdater
     from version_generator import VersionGenerator
     from DebianBuilder import DebianBuilder
@@ -204,7 +205,7 @@ def build_debian_packages(build_directory, jobs, is_official_release, sudo_creds
         print "Failed to build debian packages under {0} \ndue to {1}, Exiting now".format(build_directory, e)
         sys.exit(1)
 
-def write_downstream_parameter_file(build_directory, is_official_release, parameter_file):
+def write_downstream_parameter_file(build_directory, manifest_file, is_official_release, parameter_file):
     try:
         params = {}
 
@@ -217,10 +218,20 @@ def write_downstream_parameter_file(build_directory, is_official_release, parame
         else:
             raise RuntimeError("Version of {0} is None. Maybe the repository doesn't contain debian directory ".format(rackhd_repo_dir))
 
+        manifest = Manifest(manifest_file)
+        rackhd_commit = ''
+        for repo in manifest.repositories:
+            if repo['repository'].endswith('RackHD') or repo['repository'].endswith('RackHD.git'):
+                rackhd_commit = repo['commit-id']
+        if rackhd_commit != '':
+            params['RACKHD_COMMIT'] = rackhd_commit
+        else:
+            raise RuntimeError("commit-id of RackHD is None. Please check the manifest {0}".format(manifest_file))
+            
         # Write downstream parameters to downstream parameter file.
         common.write_parameters(parameter_file, params)
     except Exception, e:
-        raise RuntimeError("Failed to generate version file for {0} \ndue to {1}".format(repo_dir, e))
+        raise RuntimeError("Failed to write downstream parameter file \ndue to {0}".format(e))
 
 def main():
     """
@@ -230,7 +241,7 @@ def main():
     args = parse_args(sys.argv[1:])
     checkout_repos(args.manifest_file, args.build_directory, args.force, args.git_credential, args.jobs)
     build_debian_packages(args.build_directory, args.jobs, args.is_official_release, args.sudo_credential)
-    write_downstream_parameter_file(args.build_directory, args.is_official_release, args.parameter_file)
+    write_downstream_parameter_file(args.build_directory, args.manifest_file, args.is_official_release, args.parameter_file)
 
 if __name__ == '__main__':
     main()

--- a/manifest-build-tools/application/make_debian_packages.py
+++ b/manifest-build-tools/application/make_debian_packages.py
@@ -221,8 +221,10 @@ def write_downstream_parameter_file(build_directory, manifest_file, is_official_
         manifest = Manifest(manifest_file)
         rackhd_commit = ''
         for repo in manifest.repositories:
-            if repo['repository'].endswith('RackHD') or repo['repository'].endswith('RackHD.git'):
+            repository = repo['repository'].lower()
+            if repository.endswith('rackhd') or repository.endswith('rackhd.git'):
                 rackhd_commit = repo['commit-id']
+
         if rackhd_commit != '':
             params['RACKHD_COMMIT'] = rackhd_commit
         else:


### PR DESCRIPTION
**Background**:
Jenkins: the downstream jobs of "debian-build" need to get the rackhd version and rackhd commit/branch.
Because the manifest file only contains repository url and repository commit for sprint release.
We can only pass the commit to downstream jobs.

**Test**:
http://rackhdci.lss.emc.com/job/BuildRelease/job/Build/job/debian-build
