### PR TITLE
Fix: check whether the url of repository matches the url in package.j…

### DIFF
--- a/manifest-build-tools/application/reprove.py
+++ b/manifest-build-tools/application/reprove.py
@@ -387,8 +387,10 @@ class ManifestActions(object):
                         new_url = os.path.abspath(repo['directory-name'])
                         return new_url
         else:
-            new_url = "git+{url}#{pkg_version}".format(url=new_url, pkg_version=pkg_version)
-            return new_url
+            for repo in self._manifest.repositories:
+                if new_url == repo['repository']:
+                    new_url = "git+{url}#{pkg_version}".format(url=new_url, pkg_version=pkg_version)
+                    return new_url
 
         return version
 


### PR DESCRIPTION
…son before update package.json

**Background**
The script reprove.py provides multi functions: 
- checkout repositories  (read remote repository from github)
- update package.json (write local repository)
- create branch for repositories (write remote repository in github)

When the script executes the function "create branch", it will update the package.json to point to the new branch.
Only when the repository url of local repository is equal to the url in manifest file, the script updates the dependency to point to the new branch.
That prevents this kind of situation:
The url for repository on-core in manifest file is "https://github.com/RackHD-Mirror/on-http.git"
And the new branch is created for the repository under RackHD-Mirror,
But the url for the repository in package.json is  "https://github.com/RackHD/on-http.git"
The repository RackHD-Mirror/on-http will fail to run ```npm install```.
Because the new branch doesn't exist in "https://github.com/RackHD/on-http.git"

**Test**
http://rackhdci.lss.emc.com/job/BuildRelease/job/CreateBranch/