### PR TITLE
Create rackHD build in self test script

### DIFF
--- a/rackhd_BIST/README.md
+++ b/rackhd_BIST/README.md
@@ -1,0 +1,31 @@
+## RackHD BIST 
+
+RackHD Built In Self Test can be used to check health status of RackHD environment and configuration.
+
+## rackhd_bist.py
+
+This script will run RackHD BIST and log necessary information.
+
+Follow the below instructions to use this tool:
+
+ 1. Configure following items in bist_user_config.json file:
+
+    + **sourceCodeRepo**: folder path that stores RackHD source code, if not configured it is "/var/renasar/"
+    + **logPath**: RackHD BIST log path, BIST logs will be stored in the path, if not configured it is "/var/log/rackhd/"
+    + **apis**: RackHD APIs user wants to test, if not configured only SKU api will be tested
+    + **optionalStaticFiles**: static files user wants to check existence, if not configured only necessary static files will be checked
+
+ 2. Install Dependencies
+    ```
+    /on-tools/rackhd_bist$ pip install pika
+    ```
+
+ 3. Run script 
+    ```
+    /on-tools/dev_tools$ sudo python rackhd_bist.py --path <rackhd_source_code_repo> --start
+    ```
+
+    + **--path**: Specify RackHD source code repository path. If not specified, script will load source code repository path from bist_user_config.json
+    + **--start**: Leave RackHD services started after test, if rackhd_bist.py is run without this argument, RackHD services will be stopped after test
+
+

--- a/rackhd_BIST/README.md
+++ b/rackhd_BIST/README.md
@@ -1,6 +1,6 @@
 ## RackHD BIST 
 
-RackHD Built In Self Test can be used to check health status of RackHD environment and configuration.
+RackHD built-in self-test can be used to check health status of RackHD environment and configuration.
 
 ## rackhd_bist.py
 
@@ -11,7 +11,6 @@ Follow the below instructions to use this tool:
  1. Configure following items in bist_user_config.json file:
 
     + **sourceCodeRepo**: folder path that stores RackHD source code, if not configured it is "/var/renasar/"
-    + **logPath**: RackHD BIST log path, BIST logs will be stored in the path, if not configured it is "/var/log/rackhd/"
     + **apis**: RackHD APIs user wants to test, if not configured only SKU api will be tested
     + **optionalStaticFiles**: static files user wants to check existence, if not configured only necessary static files will be checked
 
@@ -20,12 +19,12 @@ Follow the below instructions to use this tool:
     /on-tools/rackhd_bist$ pip install pika
     ```
 
- 3. Run script 
+ 3. Run script
     ```
-    /on-tools/dev_tools$ sudo python rackhd_bist.py --path <rackhd_source_code_repo> --start
+    /on-tools/dev_tools$ sudo python rackhd_bist.py
     ```
-
-    + **--path**: Specify RackHD source code repository path. If not specified, script will load source code repository path from bist_user_config.json
+    There are two handy command line parameters for this script:
+    + **--path**: Specify RackHD source code repository path. A folder path string should follow it. If not specified, script will load source code repository path from bist_user_config.json
     + **--start**: Leave RackHD services started after test, if rackhd_bist.py is run without this argument, RackHD services will be stopped after test
 
 

--- a/rackhd_BIST/bist_rackhd_config.json
+++ b/rackhd_BIST/bist_rackhd_config.json
@@ -1,0 +1,108 @@
+{
+    "configFile": [
+        "/opt/onrack/etc/monorail.json",
+        "/opt/monorail/config.json"
+    ],
+    "logPath": "/var/log/rackhd/",
+    "rackhdServices": [
+        "on-taskgraph",
+        "on-http",
+        "on-syslog",
+        "on-tftp",
+        "on-dhcp-proxy"
+    ],
+    "requiredServices": [
+        "mongodb",
+        "rabbitmq-server",
+        "isc-dhcp-server"
+    ],
+    "requiredStaticFiles": [
+        {
+            "dirPath": "on-tftp/static/tftp/",
+            "fileList": [
+                "monorail-efi32-snponly.efi",
+                "monorail.intel.ipxe",
+                "monorail-undionly.kpxe",
+                "undionly.kpxe",
+                "monorail-efi64-snponly.efi",
+                "monorail.ipxe",
+                "undionly.kkpxe"
+            ]
+        },
+        {
+            "dirPath": "on-http/static/http/common/",
+            "fileList": [
+                "vmlinuz-3.16.0-25-generic",
+                "base.trusty.3.16.0-25-generic.squashfs.img",
+                "discovery.overlay.cpio.gz",
+                "initrd.img-3.16.0-25-generic"
+            ]
+        }
+    ],
+    "sourceCodeRepo": "/var/renasar/",
+    "toolList": [
+        {
+            "getVersionCommand": ["rabbitmqctl", "status"],
+            "isRequired": true,
+            "name": "rabbitmq",
+            "version": {
+                "among": [],
+                "exclusive": [],
+                "max": "2.6.10",
+                "min": "2.6.10"
+            }
+        },
+        {
+            "getVersionCommand": ["mongo", "--version"],
+            "isRequired": true,
+            "name": "mongo"
+        },
+        {
+            "getVersionCommand": ["dhcpd", "--version"],
+            "isRequired": true,
+            "name": "isc-dhcp-server",
+            "redirect": true,
+            "version": {}
+        },
+        {
+            "getVersionCommand": ["ipmitool","-V"],
+            "isRequired": true,
+            "name": "ipmitool",
+            "version": {
+                "min": "1.8.13"
+            }
+        },
+        {
+            "getVersionCommand": ["node", "--version"],
+            "isRequired": true,
+            "name": "node",
+            "version": {
+                "max": "4.99.99",
+                "min": "4.0.0"
+            }
+        },
+        {
+            "getVersionCommand": ["snmpget", "-V"],
+            "isRequired": false,
+            "name": "snmp",
+            "redirect": true
+        },
+        {
+            "getVersionCommand": ["ansible", "--version"],
+            "isRequired": false,
+            "name": "ansible",
+            "version": {
+                "exclusive": ["2.1.0.0"],
+                "min": "2.0.0.0"
+            }
+        },
+        {
+            "getVersionCommand": ["/opt/dell/srvadmin/sbin/racadm", "version"],
+            "isRequired": false,
+            "name": "racadm",
+            "version": {
+                "among": ["7.4.0"]
+            }
+        }
+    ]
+}

--- a/rackhd_BIST/bist_rackhd_config.json
+++ b/rackhd_BIST/bist_rackhd_config.json
@@ -3,7 +3,6 @@
         "/opt/onrack/etc/monorail.json",
         "/opt/monorail/config.json"
     ],
-    "logPath": "/var/log/rackhd/",
     "rackhdServices": [
         "on-taskgraph",
         "on-http",
@@ -46,23 +45,23 @@
             "isRequired": true,
             "name": "rabbitmq",
             "version": {
-                "among": [],
-                "exclusive": [],
-                "max": "2.6.10",
-                "min": "2.6.10"
+                "min": "3.2.4"
             }
         },
         {
             "getVersionCommand": ["mongo", "--version"],
             "isRequired": true,
-            "name": "mongo"
+            "name": "mongo",
+            "version": {
+                "min": "2.4.9",
+                "exclusive": ["2.6.10"]
+            }
         },
         {
             "getVersionCommand": ["dhcpd", "--version"],
             "isRequired": true,
             "name": "isc-dhcp-server",
-            "redirect": true,
-            "version": {}
+            "redirect": true
         },
         {
             "getVersionCommand": ["ipmitool","-V"],

--- a/rackhd_BIST/bist_user_config.json
+++ b/rackhd_BIST/bist_user_config.json
@@ -4,7 +4,6 @@
         "/api/current/nodes",
         "/api/current/pollers"
     ],
-    "logPath": "/var/log/rackhd/",
     "optionalStaticFiles": [
         {
             "dirPath": "on-http/static/http/common/",
@@ -17,5 +16,5 @@
             ]
         }
     ],
-    "sourceCodeRepo": "/home/onrack/src/"
+    "sourceCodeRepo": "/var/renasar/"
 }

--- a/rackhd_BIST/bist_user_config.json
+++ b/rackhd_BIST/bist_user_config.json
@@ -1,0 +1,21 @@
+{
+    "apis": [
+        "/api/current/skus",
+        "/api/current/nodes",
+        "/api/current/pollers"
+    ],
+    "logPath": "/var/log/rackhd/",
+    "optionalStaticFiles": [
+        {
+            "dirPath": "on-http/static/http/common/",
+            "fileList": [
+                "dell.raid.overlay.cpio.gz",
+                "raid.overlay.cpio.gz",
+                "secure.erase.overlay.cpio.gz",
+                "zerotouch-vEOS.swi",
+                "overlayfs_all_files.trusty.MOCKS.cpio.gz"
+            ]
+        }
+    ],
+    "sourceCodeRepo": "/home/onrack/src/"
+}

--- a/rackhd_BIST/rackhd_bist.py
+++ b/rackhd_BIST/rackhd_bist.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# Copyright 2017, Dell EMC, Inc.
+# -*- coding: UTF-8 -*-
+
+"""
+    RackHD built in self test script.
+    This script will run some tests to check RackHD configurations and RackHD running environment
+    health status.
+"""
+
+import argparse
+import test_suites
+
+parser = argparse.ArgumentParser(description='RackHD BIST arguments')
+parser.add_argument('--path', action="store", dest="path", default="",
+                    help="Specify RackHD source code path")
+parser.add_argument('--start', action="store_true", dest="start", default=False,
+                    help="Leave RackHD services in start status after BIST tests")
+arg_list = parser.parse_args()
+
+if __name__ == "__main__":
+
+    print "Starting RackHD build in self test..."
+    static_files = test_suites.StaticFiles(arg_list.path)
+    tools = test_suites.Tools()
+    rackhd_require_services = test_suites.RequiredServices()
+    hardware_resource = test_suites.HardwareResource()
+    configure_file = test_suites.RackhdConfigure()
+    rackhd_services = test_suites.RackhdServices(arg_list.path)
+    apis = test_suites.RackhdAPI()
+
+    static_files.run_test()
+    tools.run_test()
+    rackhd_require_services.run_test()
+    hardware_resource.run_test()
+    configure_file.run_test()
+    rackhd_services.run_test()
+    apis.run_test()
+    if not arg_list.start: # RackHD services will be stopped default
+        rackhd_services.stop_rackhd_services()
+    print "RackHD built in self test completed!"

--- a/rackhd_BIST/rackhd_bist.py
+++ b/rackhd_BIST/rackhd_bist.py
@@ -33,16 +33,18 @@ if __name__ == "__main__":
                         "RequiredServices", "HardwareResource",
                         "RackhdConfigure", "RackhdServices",
                         "RackhdAPI"]
-    print "Starting RackHD built-in self-test..."
+    print "\nStarting RackHD built-in self-test..."
 
     if arg_list.path:
         test_suites.CONFIGURATION["sourceCodeRepo"] = arg_list.path
 
     for test_suite in bist_test_suites:
+        test_suites.Logger.print_test_suite_name("\n" + test_suite + "\n")
         test_class = getattr(test_suites, test_suite)
         test_class().run_test()
 
     if not arg_list.start: # RackHD services will be stopped default
+        test_suites.Logger.print_test_suite_name("\nRackHDStop\n")
         test_suites.RackhdServices().stop_rackhd_services()
 
-    print "RackHD built-in self-test completed!"
+    print "\nRackHD built-in self-test completed!"

--- a/rackhd_BIST/rackhd_bist.py
+++ b/rackhd_BIST/rackhd_bist.py
@@ -4,9 +4,16 @@
 # -*- coding: UTF-8 -*-
 
 """
-    RackHD built in self test script.
+    RackHD built-in self-test script.
     This script will run some tests to check RackHD configurations and RackHD running environment
-    health status.
+    health status. RackHD BIST tests include:
+        1. RackHD services start/stop and heartbeat signals monitoring
+        2. RackHD required services status check
+        3. RackHD required tools version check
+        4. RackHD required static file existence check
+        5. RackHD configuration file validation
+        6. Optional APIs GET tests
+        7. Hardware resources check
 """
 
 import argparse
@@ -21,22 +28,21 @@ arg_list = parser.parse_args()
 
 if __name__ == "__main__":
 
-    print "Starting RackHD build in self test..."
-    static_files = test_suites.StaticFiles(arg_list.path)
-    tools = test_suites.Tools()
-    rackhd_require_services = test_suites.RequiredServices()
-    hardware_resource = test_suites.HardwareResource()
-    configure_file = test_suites.RackhdConfigure()
-    rackhd_services = test_suites.RackhdServices(arg_list.path)
-    apis = test_suites.RackhdAPI()
+    # RackHD BIST test suites in sequence
+    bist_test_suites = ["StaticFiles", "Tools",
+                        "RequiredServices", "HardwareResource",
+                        "RackhdConfigure", "RackhdServices",
+                        "RackhdAPI"]
+    print "Starting RackHD built-in self-test..."
 
-    static_files.run_test()
-    tools.run_test()
-    rackhd_require_services.run_test()
-    hardware_resource.run_test()
-    configure_file.run_test()
-    rackhd_services.run_test()
-    apis.run_test()
+    if arg_list.path:
+        test_suites.CONFIGURATION["sourceCodeRepo"] = arg_list.path
+
+    for test_suite in bist_test_suites:
+        test_class = getattr(test_suites, test_suite)
+        test_class().run_test()
+
     if not arg_list.start: # RackHD services will be stopped default
-        rackhd_services.stop_rackhd_services()
-    print "RackHD built in self test completed!"
+        test_suites.RackhdServices().stop_rackhd_services()
+
+    print "RackHD built-in self-test completed!"

--- a/rackhd_BIST/rackhd_config_template.json
+++ b/rackhd_BIST/rackhd_config_template.json
@@ -1,0 +1,58 @@
+{
+    "required": {
+        "amqp": "amqp://localhost",
+        "apiServerAddress": "172.31.128.1",
+        "apiServerPort": 9080,
+        "dhcpGateway": "172.31.128.1",
+        "dhcpProxyBindAddress": "172.31.128.1",
+        "dhcpProxyBindPort": 4011,
+        "dhcpSubnetMask": "255.255.240.0",
+        "httpEndpoints": [
+            {
+                "address": "0.0.0.0",
+                "port": 8080,
+                "httpsEnabled": false,
+                "proxiesEnabled": true,
+                "authEnabled": true,
+                "routers": "northbound-api-router"
+            },
+            {
+                "address": "0.0.0.0",
+                "port": 8443,
+                "httpsEnabled": true,
+                "proxiesEnabled": true,
+                "authEnabled": true,
+                "routers": "northbound-api-router"
+            },
+            {
+                "address": "172.31.128.1",
+                "port": 9080,
+                "httpsEnabled": false,
+                "proxiesEnabled": true,
+                "authEnabled": false,
+                "routers": "southbound-api-router"
+            }
+        ],
+        "httpDocsRoot": "./build/apidoc",
+        "httpFileServiceRoot": "./static/files",
+        "httpFileServiceType": "FileSystem",
+        "httpStaticRoot": "/opt/monorail/static/http",
+        "mongo": "mongodb://localhost/pxe",
+        "statsd": "127.0.0.1:8125",
+        "syslogBindAddress": "172.31.128.1",
+        "syslogBindPort": 514,
+        "tftpBindAddress": "172.31.128.1",
+        "tftpBindPort": 69,
+        "tftpRoot": "./static/tftp"
+    },
+    "optional":{
+        "authUsername": "",
+        "authPasswordHash": "",
+        "authPasswordSalt": "",
+        "authTokenSecret": "",
+        "authTokenExpireIn": 86400,
+        "httpProxies": "",
+        "sharedKey": "",
+        "minLogLevel": 2
+    }
+}

--- a/rackhd_BIST/test_suites.py
+++ b/rackhd_BIST/test_suites.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python
+
+# Copyright 2017, Dell EMC, Inc.
+# -*- coding: UTF-8 -*-
+
+"""
+    RackHD build in self test suites
+    This document includes RackHD BIST test suites
+"""
+
+import os
+import re
+import json
+import sys
+import httplib
+import pika
+import test_utils as utils
+
+CONFIGURATION = utils.CONFIGURATION
+Logger = utils.Logger()
+
+
+class RackhdServices(object):
+    """
+    RackHD services test suite
+    """
+    def __init__(self, path=None):
+        self.source_code_path = path or CONFIGURATION.get("sourceCodeRepo")
+        self.services = CONFIGURATION.get("rackhdServices")
+        self.heartbeat_unavailable_flags = self.services[:]
+        self.amqp_address = {"host": "localhost", "port": 5672}
+        self.amqp_connect_timeout = 20
+        self.amqp_connection = {}
+
+    def check_service_version(self):
+        """
+        Check RackHD version for each service
+        """
+        for service in self.services:
+            description = "Check service {} version".format(service)
+            commitStringPath = os.path.join(self.source_code_path, service, "commitstring.txt")
+            result = utils.robust_open_file(commitStringPath)
+            Logger.record_command_result(description, result, "warning")
+
+    def __operate_regular_rackhd(self, operator):
+        """
+        Start or stop RackHD services from regular RackHD code repo /var/renasar/
+        :param operator: operator for RackHD service, should be "start" or "stop"
+        """
+        for service in self.services:
+            description = "{} RackHD service {}".format(operator.capitalize(), service)
+            cmd = ["service", service, operator]
+            result = utils.robust_check_output(cmd)
+            Logger.record_command_result(description, result, 'error')
+
+    def __operate_user_rackhd(self, operator):
+        """
+        Start or stop RackHD services from user provided RackHD code repo
+        :param operator: operator for RackHD service, should be "start" or "stop"
+        """
+        if operator == "start":
+            for service in self.services:
+                description = "Start RackHD service {}".format(service)
+                os.chdir(os.path.join(self.source_code_path, service))
+                cmd = ["node index.js > /dev/null 2>&1 &"]  # RackHD services need run in background
+                result = utils.robust_check_output(cmd=cmd, shell=True)
+                Logger.record_command_result(description, result, 'error')
+        else:
+            get_process_cmd = ['ps aux | grep node| grep index.js | sed "/grep/d"| ' \
+                               'sed "/sudo/d" | awk \'{print $2}\' | sort -r -n']
+            output = utils.robust_check_output(cmd=get_process_cmd, shell=True)
+            process_list = output["message"].strip("\n").split("\n")
+            for kid in process_list:
+                description = "Stop RackHD service {}".format(kid)
+                cmd = ["kill", "-9", kid]
+                result = utils.robust_check_output(cmd)
+                Logger.record_command_result(description, result, 'error')
+
+    def __operate_rackhd_services(self, operator):
+        """
+        Operate RackHD services
+        :param operator: operations on RackHD services, should be either "start" or "stop"
+        """
+        assert operator in ["start", "stop"], "RackHD service operator should be start or stop"
+        if self.source_code_path != "/var/renasar" or self.source_code_path != "/var/renasar/":
+            self.__operate_user_rackhd(operator)
+        else:
+            self.__operate_regular_rackhd(operator)
+        description = "RackHD services {}ed".format(operator)
+        Logger.record_log_message(description, "", "info")
+
+    def start_rackhd_services(self):
+        """
+        Start RackHD Services
+        """
+        self.__operate_rackhd_services("start")
+
+    def stop_rackhd_services(self):
+        """
+        Stop RackHD Services
+        """
+        self.__operate_rackhd_services("stop")
+
+    def __close_amqp_connection(self):
+        """
+        Close AMQP connection
+        """
+        self.amqp_connection["channel"].stop_consuming
+        self.amqp_connection["connection"].close()
+
+    def __amqp_timeout_callback(self):
+        """
+        AMQP connection timeout handling
+        """
+        self.__close_amqp_connection()
+        description = "Connection to AMQP channels timeout"
+        details = "Can't receive heartbeat messages from services {}".format(
+            ", ".join(self.heartbeat_unavailable_flags))
+        Logger.record_log_message(description, details, "error")
+
+    def run_heartbeat_test(self):
+        """
+        Initiate AMQP to monitor hearbeat messages
+        """
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters(
+                host=self.amqp_address["host"],
+                port=self.amqp_address["port"]
+            ))
+        channel = connection.channel()
+        result = channel.queue_declare(exclusive=True)
+        queue_name = result.method.queue
+        channel.queue_bind(exchange="on.events", queue=queue_name,
+                           routing_key="heartbeat.updated.information.#")
+        connection.add_timeout(self.amqp_connect_timeout, self.__amqp_timeout_callback)
+        self.amqp_connection["channel"] = channel
+        self.amqp_connection["connection"] = connection
+        print "Waiting for RackHD services heartbeat signals..."
+        try:
+            for method_frame, properties, body in channel.consume(queue_name):
+                channel.basic_ack(method_frame.delivery_tag)
+                service = method_frame.routing_key.split('.')[-1]
+                if service in self.heartbeat_unavailable_flags:
+                    self.heartbeat_unavailable_flags.remove(service)
+                if not self.heartbeat_unavailable_flags:
+                    description = "Hearbeat signals for RackHD services are healthy"
+                    Logger.record_log_message(description, "", "debug")
+                    self.__close_amqp_connection()
+                    break
+        except pika.exceptions.ConnectionClosed:
+            description = "Failed to connection to AMQP channels"
+            Logger.record_log_message(description, "", "error")
+
+    def run_test(self):
+        """
+        Run tests for RackhdServices
+        """
+        self.check_service_version()
+        self.start_rackhd_services()
+        self.run_heartbeat_test()
+
+
+class RequiredServices(object):
+    """
+    RackHD required services test suite
+    """
+    def __init__(self):
+        self.services = CONFIGURATION.get("requiredServices")
+        self.dhcp_config_file = "/etc/dhcp/dhcpd.conf"
+        self.dhcp_ip_range = {"start_ip": '', "end_ip": ''}
+        self.dhcp_rackhd_config = {
+            "subnet": 'subnet 172\.31\.128\.0 netmask 255\.255\.252\.0\s*{' \
+                '\s*(range (172\.31\.\d{1,3}\.\d{1,3}) (172\.31\.\d{1,3}\.\d{1,3}))+;' \
+                'option vendor-class-identifier "PXEClient";\s*}',
+            "ignore-client-uids": 'ignore-client-uids.*true;',
+            "deny duplicates": 'deny.*duplicates;'
+        }
+
+    def upsert_dhcp_rackhd_config(self, key, value):
+        """
+        Update or insert dhcp RackHD configure items.
+        """
+        self.dhcp_rackhd_config[key] = value
+
+    def check_service_process(self):
+        """
+        Check RackHD required services running status
+        """
+        for service in self.services:
+            cmd = ["service", service, "status"]
+            result = utils.robust_check_output(cmd)
+            description = "Check service {} running status".format(service)
+            if result["exit_code"] == 0:
+                output = result["message"]
+                if output.find("running") == -1:
+                    result["exit_code"] = -1
+                else:
+                    result["message"] = ""  # message is not necessary for successful service
+            Logger.record_command_result(description, result, "error")
+
+    def get_dhcp_ip_count(self):
+        """
+        Get IP count that RackHD dhcp can support
+        """
+        if not (self.dhcp_ip_range["start_ip"] and self.dhcp_ip_range["end_ip"]):
+            description = "Cann't get maximum IP count supported by DHCP configure"
+            Logger.record_log_message(description, "", "warning")
+            return
+        begin_ip_bits = self.dhcp_ip_range["start_ip"].split('.')
+        end_ip_bits = self.dhcp_ip_range["end_ip"].split('.')
+        ip_count = 0
+        for begin, end in zip(begin_ip_bits, end_ip_bits):
+            ip_count = ip_count*256 + int(end) - int(begin)
+        description = "Maximum IP count supported by DHCP configure is {}".format(ip_count + 1)
+        Logger.record_log_message(description, "", "info")
+
+    def validate_dhcp_config(self):
+        """
+        Validate RackHD required dhcpd configurations
+        """
+        dhcp_config = utils.robust_open_file(self.dhcp_config_file)
+        if dhcp_config["exit_code"] != 0:
+            description = "Can't open {}".format(self.dhcp_config_file)
+            Logger.record_command_result(description, dhcp_config, "error")
+            return
+
+        # Convert useful configures to a string
+        valid_config_lines = []
+        for line in dhcp_config["message"]:
+            line = line.strip(" ").strip("\n")
+            if not line.startswith("#") and line:
+                valid_config_lines.append(line)
+        valid_config_string = "".join(valid_config_lines)
+
+        # Check RackHD required configure lines
+        unconfig_keys = self.dhcp_rackhd_config.keys()
+        subnet_match = []
+        for key, value in self.dhcp_rackhd_config.items():
+            match = re.compile(value).search(valid_config_string)
+            if match:
+                unconfig_keys.remove(key)
+                if key == "subnet":  # Get DHCP IP Range for IP count calculation
+                    subnet_match = match.groups()
+                    self.dhcp_ip_range["start_ip"] = subnet_match[1]
+                    self.dhcp_ip_range["end_ip"] = subnet_match[2]
+        for value in unconfig_keys:
+            description = "RackHD required dhcpd configure {} is incorrect".format(value)
+            Logger.record_log_message(description, "", "error")
+
+    def run_test(self):
+        """
+        Run RackHD required service tests
+        """
+        self.validate_dhcp_config()
+        self.get_dhcp_ip_count()
+        self.check_service_process()
+
+
+class RackhdConfigure(object):
+    """
+    RackHD configuration test suite
+    """
+    def __init__(self):
+        self.template_file_path = "./rackhd_config_template.json"
+        self.log_level = {
+            "required": {
+                "missing": "error",
+                "unequal": "warning"
+            },
+            "optional": {
+                "missing": "info",
+                "unequal": "debug"
+            }
+        }
+        self.config_file_paths = CONFIGURATION.get("configFile")
+        self.rackhd_config_template = {}
+        self.rackhd_config = {}
+        self.unchecked_configs = []
+
+    def load_config_file(self):
+        """
+        Load RackHD configures
+        """
+        for path in self.config_file_paths:
+            result = utils.robust_load_json_file(path)
+            if result["exit_code"]:
+                description = "Load RackHD configure file {}".format(path)
+                Logger.record_command_result(description, result, "error")
+            else:
+                self.rackhd_config = result["message"]
+                self.unchecked_configs = self.rackhd_config.keys()
+                break
+
+    def load_config_template(self):
+        """
+        Load RackHD configure template file
+        """
+        result = utils.robust_load_json_file(self.template_file_path)
+        if result["exit_code"]:
+            description = "Load RackHD configure file {}".format(self.template_file_path)
+            Logger.record_command_result(description, result, "error")
+        else:
+            self.rackhd_config_template = result["message"]
+
+    def validate_config_via_key(self, template_key):
+        """
+        Validate content of RackHD configure file against configure template key
+        :param template_key: keys in configure template
+        """
+        template = self.rackhd_config_template.get(template_key)
+        for key, value in template.items():
+            config = self.rackhd_config.get(key)
+            if config is None:
+                description = "RackHD configuration item {} is not specified".format(key)
+                Logger.record_log_message(
+                    description, '', self.log_level[template_key]["missing"])
+                continue
+            self.unchecked_configs.remove(key)
+            if value == "":  # value is empty means we don't care value of this items
+                pass
+            elif config != value:
+                description = "RackHD configuration item {} is not typical value".format(key)
+                # details = "Default value: {}, user value: {}".format(value, config)
+                details = ''
+                Logger.record_log_message(
+                    description, details, self.log_level[template_key]["unequal"])
+
+    def validate_config_items(self):
+        """
+        Validate RackHD configure files against configure template
+        """
+        for key in self.rackhd_config_template.keys():
+            self.validate_config_via_key(key)
+
+    def logging_extra_items(self):
+        """
+        Record extra items besides template items
+        """
+        for key in self.unchecked_configs:
+            description = "Configuration item {} is specified".format(key)
+            details = "{}: {}".format(key, self.rackhd_config.get(key))
+            Logger.record_log_message(description, details, "info")
+
+    def run_test(self):
+        """
+        Rackhd configure tests
+        """
+        self.load_config_file()
+        self.load_config_template()
+        if not self.rackhd_config_template:
+            return -1
+        if not self.rackhd_config:
+            print "Can't find or load RackHD configuration files, existing tests"
+            sys.exit(-1)  # Without configuration, RackHD services and APIs can't work
+        self.validate_config_items()
+        self.logging_extra_items()
+
+
+class Tools(object):
+    """
+    RackHD required tools test suite
+    """
+    def __init__(self):
+        self.tools = CONFIGURATION.get("toolList")
+
+    def validate_requirement(self, requirement, real_version):
+        """
+        Validate tool version
+        :param requirement: an object includes tool version requirement,
+            it may contains none or any of below items
+            min: required minimum version
+            max: required maximum version
+            among: version should be among a list
+            exclusive: version should not be any of a list
+        :param version: tool version got
+        :return: Boolean value, True for valid version False for invalid version
+        """
+        if not requirement:
+            return True
+        if requirement.has_key("among") and real_version not in requirement["among"]:
+            return False
+        if requirement.has_key("min") and \
+                utils.tool_version_compare(real_version, requirement["min"]) == -1:
+            return False
+        if requirement.has_key("max") and \
+                utils.tool_version_compare(real_version, requirement["max"]) == 1:
+            return False
+        if requirement.has_key("exclusive") and real_version in requirement["exclusive"]:
+            return False
+        return True
+
+    def validate_tool_list(self):
+        """
+        Validate tools
+        """
+        for tool in self.tools:
+            tool_name = tool.get("name")
+            cmd = tool.get("getVersionCommand", [tool_name, "--version"])
+            redirect_flag = tool.get("redirect", False)  # Flag for redirecting stderr to stdout
+            isRequired = tool.get("isRequired", True) # By default tool is required
+            description = "Get version for tool {}".format(tool_name)
+            version_info = utils.get_tool_version(cmd, redirect_flag)
+            if version_info["exit_code"] == 0:
+                version_requirement = tool.get("version", {})
+                is_valid = self.validate_requirement(version_requirement, version_info["message"])
+                if not is_valid:
+                    version_info["exit_code"] == -1
+                    version_info["message"] == "Tool version is invalid"
+            if isRequired:
+                level = "error"
+            else:
+                level = "info"
+            Logger.record_command_result(description, version_info, level)
+
+    def run_test(self):
+        """
+        Run tool verification test
+        """
+        self.validate_tool_list()
+
+
+class StaticFiles(object):
+    """
+    RackHD static files test suite
+    """
+    def __init__(self, path=None):
+        self.source_code_path = path or CONFIGURATION["sourceCodeRepo"]
+        self.requiredStaticFiles = CONFIGURATION["requiredStaticFiles"]
+        self.optionalStaticFiles = CONFIGURATION.get("optionalStaticFiles", [])
+
+    def check_files_existence(self, file_obj_list, log_level):
+        """
+        Check existence of files
+        :param file_obj_list: static file object list, each file object should including
+            file path and all static files under the file path
+        :param log_level: log level if error happened
+        """
+        if not file_obj_list:
+            return
+        for file_obj in file_obj_list:
+            file_path = os.path.join(self.source_code_path, file_obj.get("dirPath", ""))
+            file_list = file_obj.get("fileList", [])
+            for file_name in file_list:
+                description = "Check existence of file {}".format(file_name)
+                file_name = os.path.join(file_path, file_name)
+                if os.path.isfile(file_name):
+                    level = "debug"
+                    description += " succeeded"
+                    details = "File {} exists".format(file_name)
+                else:
+                    level = log_level
+                    description += " failed"
+                    details = "File {} doesn't exist".format(file_name)
+                Logger.record_log_message(description, details, level)
+
+    def run_test(self):
+        """
+        Run static files test
+        """
+        self.check_files_existence(self.requiredStaticFiles, 'error')
+        self.check_files_existence(self.optionalStaticFiles, 'warning')
+
+class RackhdAPI(object):
+    """
+    RackHD APIs test suite
+    """
+    def __init__(self):
+        self.api_list = CONFIGURATION["apis"]
+        self.http_method = "GET"
+        self.accepted_response_code = [200]
+        self.http_config = {
+            "host": "localhost",
+            "port": 8080,
+            "timeout": 10
+        }
+        self.get_sku_api = "/api/current/skus"
+
+    def __initiate_rackhd_connect(self):
+        """
+        Initiate RackHD http connect
+        """
+        return httplib.HTTPConnection(host=self.http_config["host"],
+                                      port=self.http_config["port"],
+                                      timeout=self.http_config["timeout"])
+
+    def get_supported_skus(self):
+        """
+        Get support skus
+        """
+        http_connect = self.__initiate_rackhd_connect()
+        http_connect.request(self.http_method, self.get_sku_api)
+        response = http_connect.getresponse()
+        if response.status not in self.accepted_response_code:
+            Logger.record_log_message("Can't get SKUs", "", "info")
+            return
+        platforms = []
+        body = json.loads(response.read())
+        for data in body:
+            platforms.append(data.get("name"))
+        if platforms:
+            description = "Injected RackHD SKUs: {}".format(" ,".join(platforms))
+        else:
+            description = "No SKU is injected"
+        Logger.record_log_message(description, "", "info")
+        http_connect.close()
+
+    def run_api_get_tests(self):
+        """
+        Run api GET tests for API list
+        """
+        for api in self.api_list:
+            http_connect = self.__initiate_rackhd_connect()
+            http_connect.request(self.http_method, api)
+            response = http_connect.getresponse()
+            if response.status not in self.accepted_response_code:
+                description = "Failed to GET API {}".format(api)
+                Logger.record_log_message(description, "", "error")
+            else:
+                description = "Succeeded to GET API {}".format(api)
+                Logger.record_log_message(description, "", "debug")
+
+    def run_test(self):
+        """
+        Run API tests
+        """
+        self.get_supported_skus()
+        self.run_api_get_tests()
+
+class HardwareResource(object):
+    """
+    RackHD hardware resource test suite
+    """
+    def __init__(self):
+        self.memory_command = ["free", "-h"]
+        self.cpu_command = ["lscpu"]
+        self.disk_command = ["fdisk", "-l"]
+
+    def get_cpu_info(self):
+        """
+        Get CPU information, command output example:
+            CPU(s):                4
+            CPU MHz:               2693.509
+            L1d cache:             32K
+            L1i cache:             32K
+            L2 cache:              256K
+            L3 cache:              20480K
+        """
+        result = utils.robust_check_output(self.cpu_command)
+        info_list = result["message"].strip("\n").strip(" ").split("\n")
+        cpu_info = {}
+        for info in info_list:
+            info = info.split(":")
+            cpu_info[info[0].strip(" ")] = info[-1].strip(" ")
+        description = "RackHD server CPU info: {}".format(str(cpu_info))
+        Logger.record_log_message(description, "", "debug")
+        return cpu_info
+
+    def get_mem_info(self):
+        """
+        Get CPU information, command output first two lines example:
+                        total       used       free     shared    buffers     cached
+            Mem:           31G       8.8G        22G       4.1M       689M       6.3G
+        """
+        result = utils.robust_check_output(self.memory_command)
+        info_list = result["message"].strip("\n").strip(" ").split("\n")
+        title_list = info_list[0].strip(" ").split(" ")
+        data_list = info_list[1].strip(" ").split(" ")
+        title_list = [x for x in title_list if x]
+        data_list = [x for x in data_list if x]
+        del data_list[0]
+        mem_info = {}
+        for title, data in zip(title_list, data_list):
+            mem_info[title] = data
+        description = "RackHD server memory info: {}".format(str(mem_info))
+        Logger.record_log_message(description, "", "debug")
+        return mem_info
+
+    def get_disk_capacity(self):
+        """
+        Get disk capacity, fdisk -l output first line example:
+            Disk /dev/sda: 104.9 GB, 104857600000 bytes
+        """
+        result = utils.robust_check_output(self.disk_command)
+        info_list = result["message"].strip("\n").strip(" ").split("\n")
+        disk_info = info_list[0]
+        pattern = re.compile("\d{0,5}\.?\d{0,3}\s+(T|G|M)B", re.I)
+        match = pattern.search(disk_info)
+        capacity = match.group()
+        description = "RackHD server disk capacity: {}".format(capacity)
+        Logger.record_log_message(description, "", "debug")
+        return capacity
+
+    def validate_resource(self):
+        """
+        Validate if RackHD server resource meet requirement:
+        TODO: RackHD hardware requirement is not defined yet, this function should be updated if
+        RackHD released hardware requirement
+        """
+        pass
+
+    def run_test(self):
+        """
+        Run hardware resource tests
+        """
+        self.get_cpu_info()
+        self.get_mem_info()
+        self.get_disk_capacity()
+        self.validate_resource()

--- a/rackhd_BIST/test_utils.py
+++ b/rackhd_BIST/test_utils.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+
+# Copyright 2017, Dell EMC, Inc.
+# -*- coding: UTF-8 -*-
+
+"""
+    Test utilities for RackHD built in self test script.
+    This file packs frequently used functions and classes for RackHD BIST
+"""
+
+import os
+import sys
+import re
+import json
+import time
+import subprocess
+import logging
+
+LOGGER_NAME = "rackhd_bist_log"
+
+def get_configurations():
+    """
+    Get BIST configurations from configure files
+    """
+    rackhd_bist_config = robust_load_json_file("./bist_rackhd_config.json")
+    if rackhd_bist_config["exit_code"]:
+        print rackhd_bist_config["message"]
+        sys.exit(-1)
+    user_bist_config = robust_load_json_file("./bist_user_config.json")
+    if user_bist_config["exit_code"]:
+        print user_bist_config["message"]
+        sys.exit(-1)
+    print "Load BIST configuration files successfully"
+
+    #user_bist_config can override rackhd_bist_config
+    return dict(rackhd_bist_config["message"], **user_bist_config["message"])
+
+def robust_load_json_file(path):
+    """
+    Load json file by given file path without breaking test
+    :param path: full file path like "/home/onrack/src/test.json"
+    :return: a dict includes exit_code and message, an example:
+        {"exit_code": 0, "message": {"config_a": 0, "config_b": 1}}
+        message is a json object if loaded json file successfully
+    """
+    exit_status = {}
+    try:
+        with open(path) as data_file:
+            json_obj = json.load(data_file)
+    except IOError:
+        exit_status["exit_code"] = -1
+        exit_status["message"] = "Can't find or unable to access {}".format(path)
+    except ValueError:
+        exit_status["exit_code"] = -1
+        exit_status["message"] = "Can't load {}, json format is required".format(path)
+    else:
+        exit_status["exit_code"] = 0
+        exit_status["message"] = json_obj
+    return exit_status
+
+def robust_check_output(cmd, shell=False, redirect=False,):
+    """
+    Subprocess check_output module with try-except to catch CalledProcessError and OSError
+    :param cmd: command option for subprocess.check_output
+    :param redirect: a flag to decide if STDERR should be re-directed to STDOUT
+    :return: a dict include exit_code and message, an example:
+        {"exit_code": 0, "message": "check_call command succeeded"}
+        message is the output string of a command if command succeeded
+    """
+    exit_status = {"exit_code": 0, "message": ""}
+    try:
+        if redirect:
+            output = subprocess.check_output(cmd, shell=shell, stderr=subprocess.STDOUT)
+        else:
+            output = subprocess.check_output(cmd, shell=shell)
+    except subprocess.CalledProcessError as err:
+        exit_status["message"] = err.output
+        exit_status["exit_code"] = err.returncode
+
+    #In redirect mode, subprocess will report OSError if command can't be found
+    except OSError as err:
+        exit_status["message"] = str(err)
+        exit_status["exit_code"] = -1
+    else:
+        exit_status["message"] = output
+    return exit_status
+
+def robust_open_file(path):
+    """
+    Open file by given file path without break test
+    :param path: full file path like "/home/onrack/src/test.py"
+    :return: a dict includes exit_code and message, an example:
+        {"exit_code": 0, "message": [...]}
+        message is a list contains file.readlines() return if file opened successfully
+    """
+    exit_status = {"exit_code": 0, "message": "check_call command succeeded"}
+    try:
+        with open(path) as data_file:
+            lines = data_file.readlines()
+    except IOError:
+        exit_status["message"] = "Can't find or access file {}".format(path)
+        exit_status["exit_code"] = -1
+    else:
+        exit_status["message"] = lines
+    return exit_status
+
+def initiate_logger(name, path):
+    """
+    Initiate bist test logging configures
+    Logs will be stored in log file as well output to console
+    :param name: logger name
+    :param path: log file path
+    :return logger: python logger object with two handlers
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    time_string = time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime())
+    logfile_name = os.path.join(path, "rackhd_bist_{}.log".format(time_string))
+    logfile = logging.FileHandler(logfile_name)
+    console = logging.StreamHandler()
+    logfile.setLevel(logging.DEBUG)  # Log file will record all messages
+    console.setLevel(logging.WARNING)  # Console will report WARNNING and ERROR
+    formatter = logging.Formatter(
+        '[%(levelname)-7s][%(asctime)-15s] %(message)s'
+    )
+    logfile.setFormatter(formatter)
+    logger.addHandler(logfile)
+    logger.addHandler(console)
+    return logger
+
+def tool_version_compare(version_a, version_b):
+    """
+    Compare for tool version:
+    :param version_a: version to be compared
+    :param version_b: version to be compared
+    :return  1:  version_a is larger than version_b
+            0:  version_a equals version b
+            -1: version-a is smaller than version b
+    """
+    version_a_bits = version_a.split(".")
+    version_b_bits = version_b.split(".")
+    if version_a_bits > version_b_bits:
+        return 1
+    elif version_a_bits < version_b_bits:
+        return -1
+    else:
+        return 0
+
+def get_tool_version(cmd, redirect=False):
+    """
+    Use given command to get tool version
+    :param cmd: command to get tool version
+    :param redirect: flag decide if we should redirect STDERR to STDOUT
+    :return: tool version string
+    """
+    result = robust_check_output(cmd=cmd, shell=False, redirect=redirect)
+    pattern = re.compile(r'\d\.(\d\.)*\d')
+    if result["exit_code"] == 0:
+        version = pattern.search(result["message"])
+        if version:
+            result["message"] = version.group(0) ## refine output message
+        else:
+            result["exit_code"] = -1
+            result["message"] = "Failed to get version with command [{}]".format(",".join(cmd))
+    return result
+
+CONFIGURATION = get_configurations()
+
+class Logger(object):
+    """
+    RackHD BIST specified logging class
+    """
+    def __init__(self):
+        self.logger = initiate_logger(
+            "rackhd_bist_log",
+            CONFIGURATION.get('logPath')
+        )
+
+    def record_log_message(self, description, details, level):
+        """
+        Record RackHD BIST log message in a unified format
+        :param description: short log description for a test, required
+        :param details: detailed information for a test, optional
+        :param level: logging level, one of ["debug", "info", "warning", "error" ]
+        """
+        assert level in ["info", "warning", "error", "debug"], "Logging level is incorrect"
+        log_message = '[message]: {}  '.format(description)
+        if details:
+            log_message = log_message + '[details]: {}'.format(details)
+        logger_method = getattr(self.logger, level)
+        logger_method(log_message)
+
+    def record_command_result(self, description, status, level):
+        """
+        Logging according command output
+        :param status: return of robust_check_output, robust_open_file or robust_load_json_file,
+            an example:
+            {"exit_code": 0, "message": "check_call command succeeded"}
+        :param description: short log description for a test
+        :param level: logging level if test failed
+        """
+        details = status["message"].strip("\n")
+        if status["exit_code"] == 0:
+            level = 'debug'
+            description = description + " succeeded"
+        else:
+            description = description + " failed"
+        self.record_log_message(description, details, level)


### PR DESCRIPTION
Why create this scripts?
We have encountered many issues that caused by RackHD environments or configurations problems, like isc-dhcp-server is not started, ansible version is incompatible, RACADM tool is not installed and so on.  Those issues is not caused by RackHD code but once they happened it will cost our time to debug. RackHD build in self test script is created to check RackHD running environments and configurations to make sure we can found such issues automatically.

Currently RackHD BIST test includes following tests:
1. RackHD services start/stop and heartbeat signals monitoring
2. RackHD required services status check
3. RackHD required tools version check
4. RackHD required static file existence check
5. RackHD configuration file validation
6. Optional APIs GET tests
7. Hardware resources check

Here is an example of BIST console output for warnings and errors:
```
onrack@Krein:~/src/on-tools/rackhd_BIST$ sudo python rackhd_bist.py
Load BIST configuration files successfully
Starting RackHD build in self tests...
[message]: RackHD configuration item httpEndpoints is not typical value
[message]: Check service on-taskgraph version failed  [details]: Can't find or access file /home/onrack/src/on-taskgraph/commitstring.txt
[message]: Check service on-http version failed  [details]: Can't find or access file /home/onrack/src/on-http/commitstring.txt
[message]: Check service on-syslog version failed  [details]: Can't find or access file /home/onrack/src/on-syslog/commitstring.txt
[message]: Check service on-tftp version failed  [details]: Can't find or access file /home/onrack/src/on-tftp/commitstring.txt
[message]: Check service on-dhcp-proxy version failed  [details]: Can't find or access file /home/onrack/src/on-dhcp-proxy/commitstring.txt
Waiting for RackHD services heartbeat signals...
RackHD built in self test completed!
```
More details will be stored in a log file in a user provided folder path (typically in /var/log/rackhd/).