### PR TITLE
RAC-4785:Run RackHD BIST script as start process

### DIFF
--- a/rackhd_BIST/bist_user_config.json
+++ b/rackhd_BIST/bist_user_config.json
@@ -16,5 +16,5 @@
             ]
         }
     ],
-    "sourceCodeRepo": "/root/src"
+    "sourceCodeRepo": "/var/renasar/"
 }

--- a/rackhd_BIST/bist_user_config.json
+++ b/rackhd_BIST/bist_user_config.json
@@ -16,5 +16,5 @@
             ]
         }
     ],
-    "sourceCodeRepo": "/var/renasar/"
+    "sourceCodeRepo": "/root/src"
 }

--- a/rackhd_BIST/test_suites.py
+++ b/rackhd_BIST/test_suites.py
@@ -547,12 +547,9 @@ class RackhdAPI(object):
         """
         Get support skus
         """
-        http_connect = self.__initiate_rackhd_connect()
-        http_connect.request(self.http_method, self.get_sku_api) 
-        response = http_connect.getresponse()
         
-        #http_connect = self.__initiate_rackhd_connect()
-        #response = self.send_http_request(http_connect, self.get_sku_api)
+        http_connect = self.__initiate_rackhd_connect()
+        response = self.send_http_request(http_connect, self.get_sku_api)
         
         if response.status >= 500:
             Logger.record_log_message("Can't get SKUs", "info", "")
@@ -560,11 +557,12 @@ class RackhdAPI(object):
         platforms = []
         body = json.loads(response.read())
         for data in body:
-            platforms.append(data.get("name"))
-        if str(platforms) == '[None]':
-            description = "No SKU is injected"
-        else: 
+            if data.get("name"):
+                platforms.append(data.get("name"))
+        if platforms:
             description = "Injected RackHD SKUs: {}".format(" ,".join(platforms))
+        else: 
+            description = "No SKU is injected"
         Logger.record_log_message(description, "info", "")
         http_connect.close()
       
@@ -573,10 +571,7 @@ class RackhdAPI(object):
         Run api GET tests for API list
         """
         for api in self.api_list:
-            #http_connect = self.__initiate_rackhd_connect()
-            #http_connect.request(self.http_method, api)
            
-            #response = http_connect.getresponse()
             http_connect = self.__initiate_rackhd_connect()
             response = self.send_http_request(http_connect, api)
     

--- a/rackhd_BIST/test_suites.py
+++ b/rackhd_BIST/test_suites.py
@@ -108,12 +108,14 @@ class RackhdServices(object):
         """
         Stop RackHD services from user provided RackHD code repo
         """
-        get_pid_cmd = ['ps aux | grep node| grep index.js | sed "/grep/d"| ' \
+        get_pid_cmd = ['ps aux | grep node | sed "/grep/d"| ' \
                             'sed "/sudo/d" | awk \'{print $2}\' | sort -r -n']
         output = utils.robust_check_output(cmd=get_pid_cmd, shell=True)
         process_list = output["message"].strip("\n").split("\n")
         for pid in process_list:
             pid_service_name = self.__get_pid_executing_path(pid).split("/")[-1]
+            if pid_service_name not in self.services:
+               continue
             kill_pid_cmd = ["kill", "-9", pid]
             result = utils.robust_check_output(kill_pid_cmd)
             description = "Stop RackHD service {}".format(pid_service_name)
@@ -515,7 +517,7 @@ class RackhdAPI(object):
     def __init__(self):
         self.api_list = CONFIGURATION["apis"]
         self.http_method = "GET"
-        self.accepted_response_code = [200]
+        #self.accepted_response_code = [200]
         self.http_config = {
             "host": "localhost",
             "port": 8080,
@@ -537,35 +539,44 @@ class RackhdAPI(object):
         """
         http_connect = self.__initiate_rackhd_connect()
         http_connect.request(self.http_method, self.get_sku_api)
-        response = http_connect.getresponse()
-        if response.status not in self.accepted_response_code:
+        
+        try:
+          response = http_connect.getresponse()
+          if response.status >= 500:
             Logger.record_log_message("Can't get SKUs", "info", "")
             return
-        platforms = []
-        body = json.loads(response.read())
-        for data in body:
+          platforms = []
+          body = json.loads(response.read())
+          for data in body:
             platforms.append(data.get("name"))
-        if platforms:
+          if platforms:
             description = "Injected RackHD SKUs: {}".format(" ,".join(platforms))
-        else:
+          else:
             description = "No SKU is injected"
-        Logger.record_log_message(description, "info", "")
-        http_connect.close()
+          Logger.record_log_message(description, "info", "")
+          http_connect.close()
+        except:
+           Logger.record_log_message("Can't get SKUs", "info", "")
 
     def run_api_get_tests(self):
         """
         Run api GET tests for API list
         """
         for api in self.api_list:
-            http_connect = self.__initiate_rackhd_connect()
-            http_connect.request(self.http_method, api)
-            response = http_connect.getresponse()
-            if response.status not in self.accepted_response_code:
+            try:
+              http_connect = self.__initiate_rackhd_connect()
+              http_connect.request(self.http_method, api)
+           
+              response = http_connect.getresponse()
+              if response.status >= 500:
                 description = "Failed to GET API {}".format(api)
                 Logger.record_log_message(description, "error", "")
-            else:
+              else:
                 description = "Succeeded to GET API {}".format(api)
                 Logger.record_log_message(description, "debug", "")
+            except:
+                description = "Failed to GET API {}".format(api)
+                Logger.record_log_message(description, "error", "")
 
     def run_test(self):
         """

--- a/rackhd_BIST/test_suites.py
+++ b/rackhd_BIST/test_suites.py
@@ -534,6 +534,11 @@ class RackhdAPI(object):
    
  
     def send_http_request(self, http_connect, http_api):
+        """
+        Define a function to catch the errors of sending http request.
+        Otherwise, it needs to catch errors many times.
+        """
+
         try:
              http_connect.request(self.http_method, http_api)
              response = http_connect.getresponse()


### PR DESCRIPTION
**Background**
Pair with @mcgg. As RackHD BIST script developer, we'd like end user can use this function easier, for example, run BIST script as start process, eg: service rackhd bist
However, the Bist script needs to be changed:
1) fix RackhdAPI error and stop rackhd service code
2) define a function of send_http_request

**TestDone**
run on exsi vm

**Reviewer**
@pengz1

